### PR TITLE
(an attempt to) Add wikidot to wiki generators list

### DIFF
--- a/code/processes/converting-process/src/main/java/nu/marginalia/converting/processor/logic/DocumentGeneratorExtractor.java
+++ b/code/processes/converting-process/src/main/java/nu/marginalia/converting/processor/logic/DocumentGeneratorExtractor.java
@@ -91,6 +91,9 @@ public class DocumentGeneratorExtractor {
             if (tag.html().contains("window.lemmyConfig")) {
                 return DocumentGenerator.of("lemmy");
             }
+            if (tag.html().contains("URL_DOMAIN = 'wikidot.com'")) {
+                return DocumentGenerator.of("wikidot");
+            }
             if (tag.attr("src").contains("wp-content")) {
                 return DocumentGenerator.of("wordpress", "wordpress-sneaky");
             }
@@ -193,7 +196,7 @@ public class DocumentGeneratorExtractor {
                 case "vbulletin", "phpbb", "mybb", "nodebb", "flarum", "tribe",
                      "discourse", "lemmy", "xenforo", "invision"
                      -> GeneratorType.FORUM;
-                case "mediawiki", "dokuwiki", "sharepoint"
+                case "mediawiki", "dokuwiki", "wikidot", "sharepoint"
                      -> GeneratorType.WIKI;
                 case "pandoc", "mkdocs", "doxygen", "javadoc"
                      -> GeneratorType.DOCS;


### PR DESCRIPTION
I have no clue if i did this correctly at all, but I noticed that a rather popular wiki generator, wikidot, was missing from the wiki matches list. This should hopefully fix that; I hope I didn't mess anything up with my tiny changes, as this is literally one of the first times i've worked with java lol