### PR TITLE
Macos apple silicon fix, and slight improvements to sample downloader

### DIFF
--- a/code/api/index-api/build.gradle
+++ b/code/api/index-api/build.gradle
@@ -44,11 +44,18 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.0.2"
+        if (osdetector.os == "osx") {
+            artifact = "com.google.protobuf:protoc:3.0.2:osx-x86_64"
+        } else {
+            artifact = "com.google.protobuf:protoc:3.0.2"
+        }
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.1.2'
+        if (osdetector.os == "osx") {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.1.2:osx-x86_64"
+        } else {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.1.2"
         }
     }
 

--- a/code/api/index-api/build.gradle
+++ b/code/api/index-api/build.gradle
@@ -52,10 +52,11 @@ protobuf {
     }
     plugins {
         grpc {
-        if (osdetector.os == "osx") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.1.2:osx-x86_64"
-        } else {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.1.2"
+            if (osdetector.os == "osx") {
+                artifact = "io.grpc:protoc-gen-grpc-java:1.1.2:osx-x86_64"
+            } else {
+                artifact = "io.grpc:protoc-gen-grpc-java:1.1.2"
+            }
         }
     }
 

--- a/run/download-samples.sh
+++ b/run/download-samples.sh
@@ -16,7 +16,7 @@ case "$1" in
 "s"|"m"|"l"|"xl")
     ;;
 *)
-    echo "Invalid argument. Must be one of 's', 'm', or 'l'."
+    echo "Invalid argument. Must be one of 's', 'm', 'l' or 'xl'."
     exit 1
     ;;
 esac
@@ -25,8 +25,6 @@ SAMPLE_NAME=crawl-${1:-m}
 SAMPLE_DIR="node-1/samples/${SAMPLE_NAME}/"
 
 function download_model {
-
-
   model=$1
   url=$2
 

--- a/run/download-samples.sh
+++ b/run/download-samples.sh
@@ -2,16 +2,37 @@
 
 set -e
 
+# Check if wget exists
+if command -v wget &> /dev/null; then
+  dl_prg="wget -O"
+elif command -v curl &> /dev/null; then
+  dl_prg="curl -o"
+else
+  echo "Neither wget nor curl found, exiting .."
+  exit 1
+fi
+
+case "$1" in
+"s"|"m"|"l"|"xl")
+    ;;
+*)
+    echo "Invalid argument. Must be one of 's', 'm', or 'l'."
+    exit 1
+    ;;
+esac
+
 SAMPLE_NAME=crawl-${1:-m}
 SAMPLE_DIR="node-1/samples/${SAMPLE_NAME}/"
 
 function download_model {
+
+
   model=$1
   url=$2
 
   if [ ! -f $model ]; then
     echo "** Downloading $url"
-    wget -O $model $url
+    $dl_prg $model $url
   fi
 }
 
@@ -23,7 +44,7 @@ fi
 
 mkdir -p node-1/samples/
 SAMPLE_TARBALL=samples/${SAMPLE_NAME}.tar.gz
-download_model ${SAMPLE_TARBALL} https://downloads.marginalia.nu/${SAMPLE_TARBALL} || rm ${SAMPLE_TARBALL}
+download_model ${SAMPLE_TARBALL} https://downloads.marginalia.nu/${SAMPLE_TARBALL}
 
 if [ ! -f ${SAMPLE_TARBALL} ]; then
   echo "!! Failed"

--- a/run/download-samples.sh
+++ b/run/download-samples.sh
@@ -42,7 +42,7 @@ fi
 
 mkdir -p node-1/samples/
 SAMPLE_TARBALL=samples/${SAMPLE_NAME}.tar.gz
-download_model ${SAMPLE_TARBALL} https://downloads.marginalia.nu/${SAMPLE_TARBALL}
+download_model ${SAMPLE_TARBALL}.tmp https://downloads.marginalia.nu/${SAMPLE_TARBALL} && mv ${SAMPLE_TARBALL}.tmp ${SAMPLE_TARBALL}
 
 if [ ! -f ${SAMPLE_TARBALL} ]; then
   echo "!! Failed"

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -12,7 +12,8 @@ function download_model {
 
   if [ ! -f $model ]; then
     echo "** Downloading $url"
-    curl -s -o $model $url
+    curl -s -o $model.tmp $url
+    mv $model.tmp $model
   fi
 }
 


### PR DESCRIPTION
the protoc libs don't exist for apple silicon. A little condition to set x86 variants for rosetta execution seems to do the trick (at least for building, haven't been able to test it).

Also, macs doesn't come with wget but curl so added a function for that.
Removed the `|| rm <file>` as it prevents the script from exiting (set -e) when preceding command has a non-zero exit.
Also slapped a quick check for the sample size arguments (display info and exit).

download-samples.sh is in gitignore, but commited anyway. Any thoughts @vlofgren?