### PR TITLE
Add Prometheus Instrumentation

### DIFF
--- a/code/services-application/search-service/src/main/java/nu/marginalia/search/svc/SearchQueryService.java
+++ b/code/services-application/search-service/src/main/java/nu/marginalia/search/svc/SearchQueryService.java
@@ -1,6 +1,7 @@
 package nu.marginalia.search.svc;
 
 import com.google.inject.Inject;
+import io.prometheus.client.Histogram;
 import lombok.SneakyThrows;
 import nu.marginalia.WebsiteUrl;
 import nu.marginalia.search.command.SearchAdtechParameter;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,8 @@ x-svc: &service
     - logs:/var/log/wmsa
   networks:
     - wmsa
-  depends_on:
-    mariadb:
-        condition: service_healthy
-
+  labels:
+    - "__meta_docker_port_private=7000"
 x-p1: &partition-1
   env_file:
     - "run/env/service.env"
@@ -198,6 +196,18 @@ services:
       - "127.0.0.1:8084:84"
       - "127.0.0.1:8090:8080"
     volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - wmsa
+  prometheus:
+    image: "prom/prometheus"
+    container_name: "prometheus"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - "127.0.0.1:8091:9090"
+    volumes:
+      - "./run/prometheus.yml:/etc/prometheus/prometheus.yml"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     networks:
       - wmsa

--- a/run/prometheus.yml
+++ b/run/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      - source_labels:
+          - '__meta_docker_network_ip'
+        target_label: '__address__'
+        replacement: '$1:7000'


### PR DESCRIPTION
The project has had instrumentation for a while, but it's been in a bad state of disrepair.  This pull request repairs the instrumentation, and adds a docker container to extract the data from the docker services into e.g. grafana. 

Instrumentation is very useful in order to evaluate performance regressions over time.  

The change implements instrumentation of query time in the search service, API gateway, query service and each index node.  
