### PR TITLE
WIP: Initial public-suffix parser for tlds 

### DIFF
--- a/code/common/config/src/main/java/nu/marginalia/WmsaHome.java
+++ b/code/common/config/src/main/java/nu/marginalia/WmsaHome.java
@@ -94,5 +94,9 @@ public class WmsaHome {
         return getHomePath().resolve("data/atags.parquet");
     }
 
+    public static Path getPublicSuffixListPath() {
+        return getHomePath().resolve("data/public_suffix_list.dat");
+    }
+
 
 }

--- a/code/libraries/tld-parser/src/build.gradle
+++ b/code/libraries/tld-parser/src/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+dependencies {
+    implementation project(':code:common:config')
+    implementation libs.bundles.slf4j
+    testImplementation libs.bundles.slf4j.test
+    testImplementation libs.bundles.junit
+    testImplementation libs.mockito
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/code/libraries/tld-parser/src/main/java/nu/marginalia/util/TldParser.java
+++ b/code/libraries/tld-parser/src/main/java/nu/marginalia/util/TldParser.java
@@ -1,4 +1,3 @@
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -8,59 +7,71 @@ import java.util.Set;
 
 /**
  * Parses the public suffix list into a HashSet.
- * Provides utility functions for stripping TLDs from the domain.
+ * Provides utility functions for stripping suffixes from the domain.
  */
 public class TldParser {
 
-    /** Parsed list of TLDs from the publicly available list */
-    public Set<String> tlds;
+    /** Parsed list of suffixes from the publicly available list */
+    public final Set<String> domainSuffixes;
 
     /**
-     * Construct TldParser by populating the hash set of tlds
+     * Construct TldParser by populating the hash set of suffixes
      * 
-     * @param tldPath path to location of public_suffix_list.dat
+     * @param suffixFilePath path to location of public_suffix_list.dat
+     * @throws IOException TODO - better error handling. works for now..
      */
-    public TldParser(String tldPath) {
-        try {
-            __parsePublicSuffixFile(tldPath);
-        } catch (IOException e) {
-            // implement - what exception do we want to throw here?
-        }
+    public TldParser(String suffixFilePath) throws IOException {
+        this.domainSuffixes = __parsePublicSuffixFile(suffixFilePath);
     }
 
     /**
-     * Return the domain as a string without the tld, ie google.com -> google
+     * Return the top level domain (suffix) from a given domain
+     * @param domain without protocol or www. 
+     * @return the tld of the given domain
+     */
+    public String getTld(String domain) {
+        
+        String[] possibleTlds = domain.split("\\.");
+
+        // Is it safe to assume that possibleTlds[0] is not a TLD?
+        for (int i = 1; i < possibleTlds.length; i++) {
+            if (this.domainSuffixes.contains(possibleTlds[i])) {
+                return possibleTlds[i];
+            }
+        } 
+        return domain;
+    }
+
+    /**
+     * Return the domain as a string without the suffix, ie google.com -> google
      * 
      * @param domain the domain to strip the TLD from
      * @return domain without TLD as string
      */
-    public String stripTld(String domain) {
-        boolean match = true;
-
-        // probably a pretty naive approach, but seems simple enough -
-        // take the domain and look up each ending until one matches
-        // ex: abc.bb.com , first look up bb.com, if that does not exist, look up com
-        while (match) {
+    public String stripDomain(String domain) {
+        
+        boolean looking = true;
+        while (looking) {
             String lookupDomain = domain.substring(domain.indexOf(".") + 1);
-            if (tlds.contains(lookupDomain)) {
+            if (domainSuffixes.contains(lookupDomain)) {
                 return domain.replace("." + lookupDomain, "");
             }
             if (!lookupDomain.contains(".")) {
-                match = false;
+                looking = false;
             }
         }
         return domain;
     }
 
     /**
-     * Given a path to a valid TLD file following the format outlined in
+     * Given a path to a valid public suffix file following the format outlined in
      * https://publicsuffix.org/list/public_suffix_list.dat, return a
-     * Set representation of all TLDs.
+     * Set representation of all suffixes
      * 
-     * @throws FileNotFoundException
+     * @throws IOException
      */
-    private void __parsePublicSuffixFile(String tldPath) throws IOException {
-        this.tlds = new HashSet<String>();
+    private static Set<String> __parsePublicSuffixFile(String tldPath) throws IOException {
+        Set<String> suffixes = new HashSet<String>();
         List<String> lines = Files.readAllLines(Paths.get(tldPath));
 
         for (String line : lines) {
@@ -77,7 +88,8 @@ public class TldParser {
             if (line.startsWith("//") || line.startsWith("!")) {
                 continue;
             }
-            this.tlds.add(line);
+            suffixes.add(line);
         }
+        return suffixes;
     }
 }

--- a/code/libraries/tld-parser/src/main/java/nu/marginalia/util/TldParser.java
+++ b/code/libraries/tld-parser/src/main/java/nu/marginalia/util/TldParser.java
@@ -1,0 +1,83 @@
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Parses the public suffix list into a HashSet.
+ * Provides utility functions for stripping TLDs from the domain.
+ */
+public class TldParser {
+
+    /** Parsed list of TLDs from the publicly available list */
+    public Set<String> tlds;
+
+    /**
+     * Construct TldParser by populating the hash set of tlds
+     * 
+     * @param tldPath path to location of public_suffix_list.dat
+     */
+    public TldParser(String tldPath) {
+        try {
+            __parsePublicSuffixFile(tldPath);
+        } catch (IOException e) {
+            // implement - what exception do we want to throw here?
+        }
+    }
+
+    /**
+     * Return the domain as a string without the tld, ie google.com -> google
+     * 
+     * @param domain the domain to strip the TLD from
+     * @return domain without TLD as string
+     */
+    public String stripTld(String domain) {
+        boolean match = true;
+
+        // probably a pretty naive approach, but seems simple enough -
+        // take the domain and look up each ending until one matches
+        // ex: abc.bb.com , first look up bb.com, if that does not exist, look up com
+        while (match) {
+            String lookupDomain = domain.substring(domain.indexOf(".") + 1);
+            if (tlds.contains(lookupDomain)) {
+                return domain.replace("." + lookupDomain, "");
+            }
+            if (!lookupDomain.contains(".")) {
+                match = false;
+            }
+        }
+        return domain;
+    }
+
+    /**
+     * Given a path to a valid TLD file following the format outlined in
+     * https://publicsuffix.org/list/public_suffix_list.dat, return a
+     * Set representation of all TLDs.
+     * 
+     * @throws FileNotFoundException
+     */
+    private void __parsePublicSuffixFile(String tldPath) throws IOException {
+        this.tlds = new HashSet<String>();
+        List<String> lines = Files.readAllLines(Paths.get(tldPath));
+
+        for (String line : lines) {
+            line = line.trim().toLowerCase();
+
+            // We only want the line up to the first whitespace
+            try {
+                line = line.split(" ")[0];
+            } catch (Exception e) {
+                continue;
+            }
+
+            // Ignore all comments and "!"
+            if (line.startsWith("//") || line.startsWith("!")) {
+                continue;
+            }
+            this.tlds.add(line);
+        }
+    }
+}

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -36,6 +36,8 @@ unzip -qn -d data data/IP2LOCATION-LITE-DB1.CSV.ZIP
 download_model data/asn-data-raw-table https://thyme.apnic.net/current/data-raw-table
 download_model data/asn-used-autnums https://thyme.apnic.net/current/data-used-autnums
 
+download_model data/public_suffix_list.dat https://publicsuffix.org/list/public_suffix_list.dat
+
 download_model data/adblock.txt https://downloads.marginalia.nu/data/adblock.txt
 if [ ! -f data/suggestions.txt ]; then
   download_model data/suggestions.txt.gz https://downloads.marginalia.nu/data/suggestions.txt.gz


### PR DESCRIPTION
For #63 - TldParser takes the list of suffixes from the https://publicsuffix.org/  and parses the list into a data structure.

From this list, `stripDomain(String domain)` can be executed to return the domain minus all known tld's from the parsed list.

This approach is rather simple, but is a good starting point for using the public suffix list. More information may be needed on the suffixes. Would love some input to see if this is headed in the right direction and if it satisfies the requirements.

I am planning to add test cases once verified if this suites the needs of the project. 