### PR TITLE
(search) Fix broken !ddg handling

### DIFF
--- a/code/services-application/search-service/src/main/java/nu/marginalia/search/command/commands/BangCommand.java
+++ b/code/services-application/search-service/src/main/java/nu/marginalia/search/command/commands/BangCommand.java
@@ -20,7 +20,7 @@ public class BangCommand implements SearchCommandInterface {
     public BangCommand()
     {
         bangsToPattern.put("!g", "https://www.google.com/search?q=%s");
-        bangsToPattern.put("!ddg", "https://duckduckgo.com/search?q=%s");
+        bangsToPattern.put("!ddg", "https://duckduckgo.com/?q=%s");
         bangsToPattern.put("!w", "https://search.marginalia.nu/search?query=%s+site:en.wikipedia.org&profile=wiki");
     }
 


### PR DESCRIPTION
https://duckduckgo.com/search?q=asdf leads to running a search for the term "search" instead of "asdf".

Both https://duckduckgo.com/asdf and https://duckduckgo.com/?q=asdf are accepted, but using GET vars seemed more in-keeping with the code.