### PR TITLE
(run/install.sh) fix docker compose file

### DIFF
--- a/run/install/docker-compose-barebones-1.yml.template
+++ b/run/install/docker-compose-barebones-1.yml.template
@@ -94,6 +94,8 @@ services:
     restart: always
     ports:
       - "127.0.0.1:2181:2181"
+    networks:
+      - wmsa
   traefik:
     image: "traefik:v2.10"
     container_name: "traefik"

--- a/run/install/docker-compose-barebones-2.yml.template
+++ b/run/install/docker-compose-barebones-2.yml.template
@@ -122,6 +122,8 @@ services:
     restart: always
     ports:
       - "127.0.0.1:2181:2181"
+    networks:
+      - wmsa
   traefik:
     image: "traefik:v2.10"
     container_name: "traefik"


### PR DESCRIPTION
I was following the release demo video for v2024.01.0 https://www.youtube.com/watch?v=PNwMkenQQ24 and when I did 'docker compose up' after installing using either option 1 or 2, the containers couldn't resolve the DNS name for 'zookeeper' I realized this was because the zookeeper container was using the default docker network, so I specified the wmsa network explicitly.

I'm just messing with this project trying to learn.