### PR TITLE
Lift JDK version to 22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
     // This is a workaround for a bug in the Jib plugin that causes it to stall randomly
     // https://github.com/GoogleContainerTools/jib/issues/3347
-    id 'com.google.cloud.tools.jib' version '3.4.0' apply(false)
+    id 'com.google.cloud.tools.jib' version '3.4.1' apply(false)
 }
 
 group 'marginalia'
@@ -43,7 +43,7 @@ subprojects.forEach {it ->
 
 }
 ext {
-    dockerImageBase='container-registry.oracle.com/graalvm/jdk:21@sha256:1fd33d4d4eba3a9e1a41a728e39ea217178d257694eea1214fec68d2ed4d3d9b'
+    dockerImageBase='container-registry.oracle.com/graalvm/jdk:22@sha256:22d2ca0d4fb378f50306ec2fda3178cce4523c4fe64e869108571c3c6e7026c8\n'
     dockerImageTag='latest'
     dockerImageRegistry='marginalia'
 }
@@ -66,7 +66,7 @@ idea {
 }
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/config/build.gradle
+++ b/code/common/config/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/db/build.gradle
+++ b/code/common/db/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/linkdb/build.gradle
+++ b/code/common/linkdb/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/model/build.gradle
+++ b/code/common/model/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/process/build.gradle
+++ b/code/common/process/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/common/renderer/build.gradle
+++ b/code/common/renderer/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/common/service/build.gradle
+++ b/code/common/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/execution/api/build.gradle
+++ b/code/execution/api/build.gradle
@@ -8,7 +8,7 @@ jar.archiveBaseName = 'execution-api'
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/execution/build.gradle
+++ b/code/execution/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/adblock/build.gradle
+++ b/code/features-convert/adblock/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/anchor-keywords/build.gradle
+++ b/code/features-convert/anchor-keywords/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/anchor-keywords/build.gradle
+++ b/code/features-convert/anchor-keywords/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     implementation libs.bundles.slf4j
     implementation libs.guice
+    implementation libs.trove
     implementation libs.bundles.mariadb
     implementation libs.duckdb
     implementation libs.notnull

--- a/code/features-convert/data-extractors/build.gradle
+++ b/code/features-convert/data-extractors/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/keyword-extraction/build.gradle
+++ b/code/features-convert/keyword-extraction/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/pubdate/build.gradle
+++ b/code/features-convert/pubdate/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/reddit-json/build.gradle
+++ b/code/features-convert/reddit-json/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/stackexchange-xml/build.gradle
+++ b/code/features-convert/stackexchange-xml/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/summary-extraction/build.gradle
+++ b/code/features-convert/summary-extraction/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-convert/topic-detection/build.gradle
+++ b/code/features-convert/topic-detection/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-crawl/content-type/build.gradle
+++ b/code/features-crawl/content-type/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-crawl/crawl-blocklist/build.gradle
+++ b/code/features-crawl/crawl-blocklist/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-crawl/link-parser/build.gradle
+++ b/code/features-crawl/link-parser/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-search/feedlot-client/build.gradle
+++ b/code/features-search/feedlot-client/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-search/random-websites/build.gradle
+++ b/code/features-search/random-websites/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/features-search/screenshots/build.gradle
+++ b/code/features-search/screenshots/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/domain-info/api/build.gradle
+++ b/code/functions/domain-info/api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/domain-info/build.gradle
+++ b/code/functions/domain-info/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/link-graph/aggregate/build.gradle
+++ b/code/functions/link-graph/aggregate/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/link-graph/api/build.gradle
+++ b/code/functions/link-graph/api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/link-graph/partition/build.gradle
+++ b/code/functions/link-graph/partition/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/math/api/build.gradle
+++ b/code/functions/math/api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/math/build.gradle
+++ b/code/functions/math/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/search-query/api/build.gradle
+++ b/code/functions/search-query/api/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/functions/search-query/build.gradle
+++ b/code/functions/search-query/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/api/build.gradle
+++ b/code/index/api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/build.gradle
+++ b/code/index/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/index-forward/build.gradle
+++ b/code/index/index-forward/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/index-journal/build.gradle
+++ b/code/index/index-journal/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/index-reverse/build.gradle
+++ b/code/index/index-reverse/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/index/query/build.gradle
+++ b/code/index/query/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/array/build.gradle
+++ b/code/libraries/array/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 
@@ -30,7 +30,7 @@ jmh {
 }
 tasks.withType(me.champeau.jmh.WithJavaToolchain).configureEach {
     javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     })
 }
 tasks.withType(me.champeau.jmh.JmhBytecodeGeneratorTask).configureEach {

--- a/code/libraries/big-string/build.gradle
+++ b/code/libraries/big-string/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/blocking-thread-pool/build.gradle
+++ b/code/libraries/blocking-thread-pool/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/braille-block-punch-cards/build.gradle
+++ b/code/libraries/braille-block-punch-cards/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/btree/build.gradle
+++ b/code/libraries/btree/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/easy-lsh/build.gradle
+++ b/code/libraries/easy-lsh/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/geo-ip/build.gradle
+++ b/code/libraries/geo-ip/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/guarded-regex/build.gradle
+++ b/code/libraries/guarded-regex/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/language-processing/build.gradle
+++ b/code/libraries/language-processing/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/message-queue/build.gradle
+++ b/code/libraries/message-queue/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/next-prime/build.gradle
+++ b/code/libraries/next-prime/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/random-write-funnel/build.gradle
+++ b/code/libraries/random-write-funnel/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/term-frequency-dict/build.gradle
+++ b/code/libraries/term-frequency-dict/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/libraries/test-helpers/build.gradle
+++ b/code/libraries/test-helpers/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/process-models/crawl-spec/build.gradle
+++ b/code/process-models/crawl-spec/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/process-models/crawling-model/build.gradle
+++ b/code/process-models/crawling-model/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/process-models/processed-data/build.gradle
+++ b/code/process-models/processed-data/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/process-models/work-log/build.gradle
+++ b/code/process-models/work-log/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/process-mqapi/build.gradle
+++ b/code/process-mqapi/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/converting-process/build.gradle
+++ b/code/processes/converting-process/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/writer/ConverterBatchWriter.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/writer/ConverterBatchWriter.java
@@ -2,6 +2,7 @@ package nu.marginalia.converting.writer;
 
 import gnu.trove.list.TLongList;
 import gnu.trove.list.array.TLongArrayList;
+import lombok.SneakyThrows;
 import nu.marginalia.converting.model.ProcessedDocument;
 import nu.marginalia.converting.model.ProcessedDomain;
 import nu.marginalia.converting.sideload.SideloadSource;
@@ -61,6 +62,7 @@ public class ConverterBatchWriter implements AutoCloseable, ConverterBatchWriter
     }
 
     @Override
+    @SneakyThrows
     public void writeProcessedDomain(ProcessedDomain domain) {
         var results = ForkJoinPool.commonPool().invokeAll(
                 writeTasks(domain)

--- a/code/processes/crawling-process/build.gradle
+++ b/code/processes/crawling-process/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/index-constructor-process/build.gradle
+++ b/code/processes/index-constructor-process/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/loading-process/build.gradle
+++ b/code/processes/loading-process/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/test-data/build.gradle
+++ b/code/processes/test-data/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/processes/website-adjacencies-calculator/build.gradle
+++ b/code/processes/website-adjacencies-calculator/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/services-application/api-service/build.gradle
+++ b/code/services-application/api-service/build.gradle
@@ -3,12 +3,12 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/services-application/dating-service/build.gradle
+++ b/code/services-application/dating-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -18,7 +18,7 @@ apply from: "$rootProject.projectDir/docker.gradle"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/services-application/explorer-service/build.gradle
+++ b/code/services-application/explorer-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -18,7 +18,7 @@ apply from: "$rootProject.projectDir/docker.gradle"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/services-application/search-service/build.gradle
+++ b/code/services-application/search-service/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'application'
     id 'jvm-test-suite'
 
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -18,7 +18,7 @@ tasks.distZip.enabled = false
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 sass {

--- a/code/services-core/assistant-service/build.gradle
+++ b/code/services-core/assistant-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -15,7 +15,7 @@ tasks.distZip.enabled = false
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/services-core/control-service/build.gradle
+++ b/code/services-core/control-service/build.gradle
@@ -2,12 +2,12 @@ plugins {
     id 'java'
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/services-core/executor-service/build.gradle
+++ b/code/services-core/executor-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -17,7 +17,7 @@ tasks.distZip.enabled = false
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/services-core/index-service/build.gradle
+++ b/code/services-core/index-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -18,7 +18,7 @@ apply from: "$rootProject.projectDir/docker.gradle"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 apply from: "$rootProject.projectDir/srcsets.gradle"

--- a/code/services-core/query-service/build.gradle
+++ b/code/services-core/query-service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 application {
@@ -18,7 +18,7 @@ apply from: "$rootProject.projectDir/docker.gradle"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/tools/crawl-data-unfcker/build.gradle
+++ b/code/tools/crawl-data-unfcker/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/tools/experiment-runner/build.gradle
+++ b/code/tools/experiment-runner/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/tools/load-test/build.gradle
+++ b/code/tools/load-test/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/code/tools/screenshot-capture-tool/build.gradle
+++ b/code/tools/screenshot-capture-tool/build.gradle
@@ -3,12 +3,12 @@ plugins {
 
     id 'application'
     id 'jvm-test-suite'
-    id 'com.google.cloud.tools.jib' version '3.4.0'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/run/readme.md
+++ b/run/readme.md
@@ -11,7 +11,7 @@ documentation.
 **Docker** - It is a bit of a pain to install, but if you follow
 [this guide](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) you're on the right track for ubuntu-like systems.
 
-**JDK 21** - The code uses Java 21 preview features. 
+**JDK 22** - The code uses Java 22 preview features. 
 The civilized way of installing this is to use [SDKMAN](https://sdkman.io/);
 graalce is a good distribution choice but it doesn't matter too much.
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -128,7 +128,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         libs {
-            library('lombok', 'org.projectlombok', 'lombok').version('1.18.30')
+            library('lombok', 'org.projectlombok', 'lombok').version('1.18.32')
             library('mariadb-client', 'org.mariadb.jdbc', 'mariadb-java-client').version('3.0.6')
             library('hikaricp', 'com.zaxxer:HikariCP:5.0.1')
 

--- a/third-party/commons-codec/build.gradle
+++ b/third-party/commons-codec/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/count-min-sketch/build.gradle
+++ b/third-party/count-min-sketch/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/encyclopedia-marginalia-nu/build.gradle
+++ b/third-party/encyclopedia-marginalia-nu/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/monkey-patch-opennlp/build.gradle
+++ b/third-party/monkey-patch-opennlp/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/openzim/build.gradle
+++ b/third-party/openzim/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/parquet-floor/build.gradle
+++ b/third-party/parquet-floor/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/porterstemmer/build.gradle
+++ b/third-party/porterstemmer/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/rdrpostagger/build.gradle
+++ b/third-party/rdrpostagger/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 

--- a/third-party/symspell/build.gradle
+++ b/third-party/symspell/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(22))
     }
 }
 


### PR DESCRIPTION
A new JDK version is out, and Marginalia is on the bleeding edge as always.  Upgrade isn't expected to cause any major issues. 

Migrating to a newer JDK also entails upgrading JIB to 3.4.1 and Lombok to 1.18.32.