### PR TITLE
Accessibility improvements

### DIFF
--- a/code/common/service/java/nu/marginalia/service/module/DatabaseModule.java
+++ b/code/common/service/java/nu/marginalia/service/module/DatabaseModule.java
@@ -12,6 +12,7 @@ import org.mariadb.jdbc.Driver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -46,7 +47,6 @@ public class DatabaseModule extends AbstractModule {
                 new Flyway(config.getConfiguration()).migrate();
             }
         }
-
     }
 
     private Properties loadDbProperties() {

--- a/code/common/service/resources/log4j2-json.xml
+++ b/code/common/service/resources/log4j2-json.xml
@@ -7,7 +7,7 @@
                 <MarkerFilter marker="HTTP" onMatch="DENY" onMismatch="NEUTRAL" />
             </Filters>
         </Console>
-        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
+        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:-/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
                      ignoreExceptions="false">
             <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true"/>
             <Filters>

--- a/code/common/service/resources/log4j2-prod.xml
+++ b/code/common/service/resources/log4j2-prod.xml
@@ -7,7 +7,7 @@
                 <MarkerFilter marker="HTTP" onMatch="DENY" onMismatch="NEUTRAL" />
             </Filters>
         </Console>
-        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
+        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:-/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
                      ignoreExceptions="false">
             <PatternLayout>
                 <Pattern>%-5level %d{yyyy-MM-dd HH:mm:ss,SSS} %-20t %-20c{1}: %msg{nolookups}%n</Pattern>

--- a/code/common/service/resources/log4j2-test.xml
+++ b/code/common/service/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
                 <MarkerFilter marker="HTTP" onMatch="DENY" onMismatch="NEUTRAL" />
             </Filters>
         </Console>
-        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
+        <RollingFile name="LogToFile" fileName="${env:WMSA_LOG_DIR:-/var/log/wmsa}/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}.log" filePattern="/var/log/wmsa/wmsa-${sys:service-name}-${env:WMSA_SERVICE_NODE:-0}-log-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz"
                      ignoreExceptions="false">
             <PatternLayout>
                 <Pattern>%-5level %d{yyyy-MM-dd HH:mm:ss,SSS} %-20t %-20c{1}: %msg{nolookups}%n</Pattern>

--- a/code/services-application/dating-service/resources/templates/dating/dating-view.hdb
+++ b/code/services-application/dating-service/resources/templates/dating/dating-view.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Website Explorer - {{url}}</title>

--- a/code/services-application/explorer-service/resources/templates/explorer/explorer.hdb
+++ b/code/services-application/explorer-service/resources/templates/explorer/explorer.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 <head>
 <meta charset="UTF-8">
 {{#if query}} <title>Websites Similar To {{query}}</title> {{/if}}

--- a/code/services-application/search-service/build.gradle
+++ b/code/services-application/search-service/build.gradle
@@ -73,5 +73,15 @@ dependencies {
     testImplementation libs.bundles.junit
     testImplementation libs.mockito
 
+    testImplementation platform('org.testcontainers:testcontainers-bom:1.17.4')
+    testImplementation 'org.testcontainers:mariadb:1.17.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.17.4'
+    testImplementation project(':code:libraries:test-helpers')
 }
 
+tasks.register('paperDoll', Test) {
+    useJUnitPlatform {
+        includeTags "paperdoll"
+    }
+    jvmArgs = [ '-DrunPaperDoll=true', '--enable-preview' ]
+}

--- a/code/services-application/search-service/java/nu/marginalia/search/command/SearchParameters.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/command/SearchParameters.java
@@ -17,33 +17,34 @@ public record SearchParameters(String query,
                                SearchRecentParameter recent,
                                SearchTitleParameter searchTitle,
                                SearchAdtechParameter adtech,
-                               boolean poisonResults
+                               boolean poisonResults,
+                               boolean newFilter
                                ) {
     public String profileStr() {
         return profile.filterId;
     }
 
     public SearchParameters withProfile(SearchProfile profile) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
     }
 
     public SearchParameters withJs(SearchJsParameter js) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
     }
     public SearchParameters withAdtech(SearchAdtechParameter adtech) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
     }
 
     public SearchParameters withRecent(SearchRecentParameter recent) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
     }
 
     public SearchParameters withTitle(SearchTitleParameter title) {
-        return new SearchParameters(query, profile, js, recent, title, adtech, poisonResults);
+        return new SearchParameters(query, profile, js, recent, title, adtech, poisonResults, true);
     }
 
     public String renderUrl(WebsiteUrl baseUrl) {
-        String path = String.format("/search?query=%s&profile=%s&js=%s&adtech=%s&recent=%s&searchTitle=%s",
+        String path = String.format("/search?query=%s&profile=%s&js=%s&adtech=%s&recent=%s&searchTitle=%s&newfilter=true",
                 URLEncoder.encode(query, StandardCharsets.UTF_8),
                 URLEncoder.encode(profile.filterId, StandardCharsets.UTF_8),
                 URLEncoder.encode(js.value, StandardCharsets.UTF_8),

--- a/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
@@ -26,4 +26,5 @@ public class DecoratedSearchResults {
     public String getAdtech() { return params.adtech().value; }
     public String getRecent() { return params.recent().value; }
     public String getSearchTitle() { return params.searchTitle().value; }
+    public Boolean isNewFilter() { return params.newFilter(); }
 }

--- a/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
@@ -7,7 +7,13 @@ import nu.marginalia.search.command.SearchParameters;
 
 import java.util.List;
 
-@AllArgsConstructor @Getter @Builder
+/** A class to hold details about the search results,
+ * as used by the handlebars templating engine to render
+ * the search results page.
+ */
+@AllArgsConstructor
+@Getter
+@Builder
 public class DecoratedSearchResults {
     private final SearchParameters params;
     private final List<String> problems;
@@ -19,7 +25,9 @@ public class DecoratedSearchResults {
     private final int focusDomainId;
     private final SearchFilters filters;
 
-    // These are used by the search form
+    // These are used by the search form, they look unused in the IDE but are used by the mustache template,
+    // DO NOT REMOVE THEM
+    public int getResultCount() { return results.size(); }
     public String getQuery() { return params.query(); }
     public String getProfile() { return params.profile().filterId; }
     public String getJs() { return params.js().value; }

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
@@ -7,6 +7,7 @@ import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.DomainIndexingState;
 import nu.marginalia.model.crawl.HtmlFeature;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
@@ -104,25 +105,25 @@ public class UrlDetails implements Comparable<UrlDetails> {
         return Integer.bitCount(features & mask);
     }
 
-    public String getProblems() {
-        StringJoiner sj = new StringJoiner(", ");
+    public List<UrlProblem> getProblems() {
+        List<UrlProblem> problems = new ArrayList<>();
 
         if (isScripts()) {
-            sj.add("Javascript");
+            problems.add(new UrlProblem("Js", "The page uses Javascript"));
         }
         if (isCookies()) {
-            sj.add("Cookies");
+            problems.add(new UrlProblem("Co", "The page uses Cookies"));
         }
         if (isTracking()) {
-            sj.add("Tracking/Analytics");
+            problems.add(new UrlProblem("Tr", "The page uses Tracking/Analytics"));
         }
         if (isAffiliate()) {
-            sj.add("Affiliate Linking");
+            problems.add(new UrlProblem("Af", "The page may use Affiliate Linking"));
         }
         if (isAds()) {
-            sj.add("Ads/Adtech Tracking");
+            problems.add(new UrlProblem("Ad", "The page uses Ads/Adtech Tracking"));
         }
-        return sj.toString();
+        return problems;
 
     }
 
@@ -150,5 +151,9 @@ public class UrlDetails implements Comparable<UrlDetails> {
         if (termScore <= 5) return 5;
 
         return 10;
+    }
+
+    public static record UrlProblem(String name, String description) {
+
     }
 }

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
@@ -30,6 +30,7 @@ public class UrlDetails implements Comparable<UrlDetails> {
     public int resultsFromSameDomain;
 
     public String positions;
+    public int positionsCount;
     public SearchResultItem resultItem;
     public List<SearchResultKeywordScore> keywordScores;
 

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryIndexService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryIndexService.java
@@ -89,6 +89,7 @@ public class SearchQueryIndexService {
                     detail.rankingScore, // termScore
                     detail.resultsFromDomain(),
                     getPositionsString(detail),
+                    Long.bitCount(detail.bestPositions),
                     detail.rawIndexResult,
                     detail.rawIndexResult.keywordScores
             ));

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryService.java
@@ -58,7 +58,8 @@ public class SearchQueryService {
                     SearchRecentParameter.parse(request.queryParams("recent")),
                     SearchTitleParameter.parse(request.queryParams("searchTitle")),
                     SearchAdtechParameter.parse(request.queryParams("adtech")),
-                    "1".equals(request.headers("X-Poison-Results"))
+                    "1".equals(request.headers("X-Poison-Results")),
+                    "true".equals(request.queryParams("newfilter"))
             );
         }
         catch (Exception ex) {

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -155,7 +155,7 @@ header {
               rgba(100,255,100,1) 50%,
               rgba(100,100,255,1) 100%);
       color: black;
-      text-shadow: 0 0 0.25ch #ccc;
+      text-shadow: 0 0 0.5ch #fff;
     }
 
     a:hover, a:focus {

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -6,6 +6,7 @@ $highlight-dark: #2f4858;
 $highlight-light: #3F5F6F;
 $highlight-light2: #eee;
 $border-color: #ccc;
+$border-color2: #aaa;
 $heading-fonts: serif;
 $visited: #fcc;
 
@@ -117,7 +118,7 @@ body {
 }
 
 .dialog {
-  border: 1px solid $border-color;
+  border: 1px solid $border-color2;
   box-shadow: 0 0 1ch $border-color;
   background-color: #fff;
   padding: 1ch;
@@ -212,7 +213,7 @@ header {
   background-color: #fff;
   padding: 1ch;
   margin: 1ch;
-  border: 1px solid $border-color;
+  border: 1px solid $border-color2;
   box-shadow: 0 0 1ch $border-color;
 }
 
@@ -312,7 +313,7 @@ footer {
     flex-grow: 1.1;
 
     background-color: #fff;
-    border-left: 1px solid $border-color;
+    border-left: 1px solid $border-color2;
     box-shadow: -1px -1px 5px $border-color;
 
     padding-left: 1ch;
@@ -328,7 +329,7 @@ footer {
 }
 
 .shadowbox {
-  box-shadow: 0 0 1ch $border-color;
+  box-shadow: 0 0 1ch $border-color2;
   border: 1px solid $border-color;
 }
 
@@ -336,7 +337,7 @@ footer {
   margin: 0;
   padding: 0.5ch;
   background-color: $highlight-light;
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid $border-color2;
   font-family: $heading-fonts;
   font-weight: normal;
   color: $fg-light;
@@ -468,14 +469,14 @@ footer {
     font-family: monospace;
     font-size: 12pt;
     padding: 0.5ch;
-    border: 1px solid $border-color;
+    border: 1px solid $border-color2;
     background-color: $fg-light;
     color: $fg-dark;
   }
 
   input[type="submit"] {
     font-size: 12pt;
-    border: 1px solid $border-color;
+    border: 1px solid $border-color2;
     background-color: $fg-light;
     color: $fg-dark;
   }
@@ -542,7 +543,7 @@ footer {
   }
 
   hr {
-    border-top: 0.5px solid $border-color;
+    border-top: 0.5px solid $border-color2;
     border-bottom: none;
   }
   ul {

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -29,8 +29,8 @@ body {
   font-family: sans-serif;
   font-size: 14px;
   line-height: 1.6;
-  margin-left: 2ch;
-  margin-right: 4ch;
+  margin-left: auto;
+  margin-right: auto;
   max-width: 120ch;
   padding: 0;
 }

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -706,3 +706,11 @@ footer {
 // hidden on modern browsers via CSS.
 
 hr.w3m-helper { display: none; }
+.screenreader-only {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -706,6 +706,10 @@ footer {
 // hidden on modern browsers via CSS.
 
 hr.w3m-helper { display: none; }
+
+// This is a screenreader-only class that hides content from visual browsers, but allows screenreaders and
+// text-based browsers to access it.
+
 .screenreader-only {
   position:absolute;
   left:-10000px;

--- a/code/services-application/search-service/resources/templates/search/browse-result.hdb
+++ b/code/services-application/search-service/resources/templates/search/browse-result.hdb
@@ -2,7 +2,7 @@
     <h2 title="{{url.domain}}">{{displayDomain}}</h2>
 
     <a href="{{url.proto}}://{{url.domain}}/">
-        <img src="/screenshot/{{domainId}}" title="{{description}}" loading="lazy" width="400" height="300" />
+        <img src="/screenshot/{{domainId}}" title="{{displayDomain}} screenshot" alt="{{displayDomain}} screenshot" loading="lazy" width="400" height="300" />
     </a>
 
     <div class="utils">

--- a/code/services-application/search-service/resources/templates/search/browse-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/browse-results.hdb
@@ -14,7 +14,7 @@
 
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
-
+<span id="content-start"></span>
 <div class="infobox">
 {{#if focusDomain}}
   Showing domains similar to <tt>{{focusDomain}}</tt>.

--- a/code/services-application/search-service/resources/templates/search/browse-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/browse-results.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{query}}</title>

--- a/code/services-application/search-service/resources/templates/search/conversion-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/conversion-results.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{query}}</title>

--- a/code/services-application/search-service/resources/templates/search/conversion-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/conversion-results.hdb
@@ -13,7 +13,7 @@
 
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
-
+<span id="content-start"></span>
 <div class="infobox">
     {{query}} = {{result}}
 </div>

--- a/code/services-application/search-service/resources/templates/search/dictionary-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/dictionary-results.hdb
@@ -13,7 +13,7 @@
 
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
-
+<span id="content-start"></span>
 <div class="infobox">
 {{#unless entries}}
 No definitions were found for that word

--- a/code/services-application/search-service/resources/templates/search/dictionary-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/dictionary-results.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{query}}</title>

--- a/code/services-application/search-service/resources/templates/search/error-page-search.hdb
+++ b/code/services-application/search-service/resources/templates/search/error-page-search.hdb
@@ -14,7 +14,7 @@
 
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
-
+<span id="content-start"></span>
 <div class="infobox">
     <h2> {{ title }} </h2>
     <div class="info"> {{{message}}} </div>

--- a/code/services-application/search-service/resources/templates/search/error-page-search.hdb
+++ b/code/services-application/search-service/resources/templates/search/error-page-search.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{title}}</title>

--- a/code/services-application/search-service/resources/templates/search/error-page.hdb
+++ b/code/services-application/search-service/resources/templates/search/error-page.hdb
@@ -1,4 +1,4 @@
-<html>
+<html lang="en-US">
     <head>
         <title>Error</title>
         <link rel="stylesheet" href="serp.css">

--- a/code/services-application/search-service/resources/templates/search/index/index.hdb
+++ b/code/services-application/search-service/resources/templates/search/index/index.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search</title>

--- a/code/services-application/search-service/resources/templates/search/parts/search-form.hdb
+++ b/code/services-application/search-service/resources/templates/search/parts/search-form.hdb
@@ -11,7 +11,7 @@
         <input type="hidden" name="profile" value="{{profile}}">
         <input type="hidden" name="recent" value="{{recent}}">
 
-        <input type="submit" form="search-form" title="Execute Search" value="Search">
+        <input type="submit" form="search-form" title="Execute Search" value="Search" autocomplete="off">
     </div>
 </form>
 <!-- load the first stage mobile customizations script early to avoid flicker -->

--- a/code/services-application/search-service/resources/templates/search/parts/search-header.hdb
+++ b/code/services-application/search-service/resources/templates/search/parts/search-header.hdb
@@ -1,6 +1,7 @@
 <a name="top"></a>
 <header>
     <nav>
+        <a href="#" class="screenreader-only" onClick="">Skip to content</a>
         <a href="https://www.marginalia.nu/">Marginalia</a>
         <a href="https://memex.marginalia.nu/projects/edge/about.gmi">About</a>
         <a href="https://memex.marginalia.nu/projects/edge/supporting.gmi">Donate</a>

--- a/code/services-application/search-service/resources/templates/search/parts/search-result.hdb
+++ b/code/services-application/search-service/resources/templates/search/parts/search-result.hdb
@@ -10,7 +10,9 @@
     <a href="/site/{{url.domain}}" title="Domain Information">Info</a>
     {{#if hasMoreResults}}<a href="/site-search/{{url.domain}}/{{query}}?profile={{profile}}" title="More results from this domain">{{resultsFromSameDomain}}+</a>{{/if}}{{/unless}}
     <div class="meta">
-        {{#if problemCount}} <span class="problems" title="{{problems}}"> ⚠ {{problemCount}} </span> {{/if}}
+        {{#each problems}}
+            <span class="problem" title="{{description}}">{{name}}</span>
+        {{/each}}
         <span aria-hidden="true" class="meta positions"
               title="Positions where keywords were found within the document">{{positions}}</span>
         <div class="screenreader-only">Terms appear in {{positionsCount}} positions</div>

--- a/code/services-application/search-service/resources/templates/search/parts/search-result.hdb
+++ b/code/services-application/search-service/resources/templates/search/parts/search-result.hdb
@@ -13,6 +13,7 @@
         {{#if problemCount}} <span class="problems" title="{{problems}}"> ⚠ {{problemCount}} </span> {{/if}}
         <span aria-hidden="true" class="meta positions"
               title="Positions where keywords were found within the document">{{positions}}</span>
+        <div class="screenreader-only">Terms appear in {{positionsCount}} positions</div>
     </div>
 </div>
 </section>

--- a/code/services-application/search-service/resources/templates/search/search-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/search-results.hdb
@@ -12,10 +12,13 @@
 
 <body data-filter="{{filters.currentFilter}}">
 
+{{#if newFilter}} <div class="screenreader-only" aria-role="status">Search Filters Updated</div> {{/if}}
+
 <!-- Hi there, fellow human being :-) -->
 
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
+
 
 <span id="content-start"></span>
 

--- a/code/services-application/search-service/resources/templates/search/search-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/search-results.hdb
@@ -29,6 +29,11 @@
                 Showing search results from <a href="/site/{{focusDomain}}">{{focusDomain}}</a>.
             </div>
         {{/if}}
+        {{#unless focusDomain}}
+            <div class="infobox screenreader-only">
+                Showing {{resultCount}} search results.
+            </div>
+        {{/unless}}
         {{#each results}}
             {{#if hasMultiple}}
                 {{>search/parts/search-result-rest}}

--- a/code/services-application/search-service/resources/templates/search/search-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/search-results.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{query}}</title>

--- a/code/services-application/search-service/resources/templates/search/search-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/search-results.hdb
@@ -17,6 +17,8 @@
 {{>search/parts/search-header}}
 {{>search/parts/search-form}}
 
+<span id="content-start"></span>
+
 <section class="sidebar-narrow">
     <section id="results" class="sb-left">
         {{#if focusDomain}}

--- a/code/services-application/search-service/resources/templates/search/site-info/site-crosstalk.hdb
+++ b/code/services-application/search-service/resources/templates/search/site-info/site-crosstalk.hdb
@@ -12,8 +12,9 @@
 <body>
 
 {{>search/parts/search-header}}
-
 {{>search/parts/search-form}}
+
+<span id="content-start"></span>
 
 <div class="infobox">
     Showing results containing links between <a href="/site/{{domainA}}">{{domainA}}</a> and <a href="/site/{{domainB}}">{{domainB}}</a>.

--- a/code/services-application/search-service/resources/templates/search/site-info/site-crosstalk.hdb
+++ b/code/services-application/search-service/resources/templates/search/site-info/site-crosstalk.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{domainA}} and {{domainB}}</title>

--- a/code/services-application/search-service/resources/templates/search/site-info/site-info.hdb
+++ b/code/services-application/search-service/resources/templates/search/site-info/site-info.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Marginalia Search - {{domain}}</title>

--- a/code/services-application/search-service/resources/templates/search/site-info/site-info.hdb
+++ b/code/services-application/search-service/resources/templates/search/site-info/site-info.hdb
@@ -14,6 +14,7 @@
 {{>search/parts/search-header}}
 
 {{>search/parts/search-form}}
+<span id="content-start"></span>
 
 {{#with view}}
 <nav id="siteinfo-nav">

--- a/code/services-application/search-service/test/nu/marginalia/search/command/commands/BangCommandTest.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/command/commands/BangCommandTest.java
@@ -15,7 +15,7 @@ class BangCommandTest {
         try {
             bangCommand.process(null,
                     new SearchParameters(" !g test",
-                    null, null, null, null, null, false)
+                    null, null, null, null, null, false, false)
             );
             Assertions.fail("Should have thrown RedirectException");
         }

--- a/code/services-application/search-service/test/nu/marginalia/search/paperdoll/SearchServicePaperDoll.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/paperdoll/SearchServicePaperDoll.java
@@ -1,0 +1,167 @@
+package nu.marginalia.search.paperdoll;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.SneakyThrows;
+import nu.marginalia.api.searchquery.QueryClient;
+import nu.marginalia.api.searchquery.model.query.QueryResponse;
+import nu.marginalia.api.searchquery.model.query.SearchQuery;
+import nu.marginalia.api.searchquery.model.query.SearchSpecification;
+import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
+import nu.marginalia.api.searchquery.model.results.ResultRankingParameters;
+import nu.marginalia.api.searchquery.model.results.SearchResultItem;
+import nu.marginalia.index.query.limit.QueryLimits;
+import nu.marginalia.index.query.limit.QueryStrategy;
+import nu.marginalia.index.query.limit.SpecificationLimit;
+import nu.marginalia.model.EdgeUrl;
+import nu.marginalia.model.crawl.HtmlFeature;
+import nu.marginalia.search.SearchModule;
+import nu.marginalia.search.SearchService;
+import nu.marginalia.service.ServiceId;
+import nu.marginalia.service.discovery.ServiceRegistryIf;
+import nu.marginalia.service.discovery.property.ServiceEndpoint;
+import nu.marginalia.service.module.ServiceConfigurationModule;
+import nu.marginalia.test.TestMigrationLoader;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+/** This class is a special test class that sets up a search service
+ * and registers some search results, without actually starting the rest
+ * of the environment. This is used to test the search service in isolation
+ * when working on the frontend.
+ * <p></p>
+ * It's not actually a test, but it's in the test directory because it's
+ * using test related classes.
+ * <p></p>
+ * When using gradle, run ./gradlew paperDoll --info to run this test,
+ * the system will wait for you to kill the process to stop the test,
+ * and the UI is available at port 9999.
+ */
+@Testcontainers
+@Tag("paperdoll")
+public class SearchServicePaperDoll extends AbstractModule {
+
+    @Container
+    static MariaDBContainer<?> mariaDBContainer = new MariaDBContainer<>("mariadb")
+            .withDatabaseName("WMSA_prod")
+            .withUsername("wmsa")
+            .withPassword("wmsa")
+            .withNetworkAliases("mariadb");
+
+    private static HikariDataSource dataSource;
+
+    private static List<DecoratedSearchResultItem> results = new ArrayList<>();
+    private static QueryResponse searchResponse;
+
+    @SneakyThrows
+    void registerSearchResult(
+            String url,
+            String title,
+            String description,
+            Collection<HtmlFeature> features,
+            double quality,
+            double score,
+            long positions)
+    {
+        results.add(new DecoratedSearchResultItem(
+                new SearchResultItem(url.hashCode(), 2, 3, false),
+                new EdgeUrl(url),
+                title,
+                description,
+                quality,
+                "HTML5",
+                HtmlFeature.encode(features),
+                null,
+                url.hashCode(),
+                400,
+                positions,
+                score,
+                null)
+        );
+    }
+
+    @BeforeAll
+    public static void setup() throws URISyntaxException {
+        if (!Boolean.getBoolean("runPaperDoll")) {
+            return;
+        }
+
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(mariaDBContainer.getJdbcUrl());
+        config.setUsername("wmsa");
+        config.setPassword("wmsa");
+
+        dataSource = new HikariDataSource(config);
+
+        TestMigrationLoader.flywayMigration(dataSource);
+
+        System.setProperty("service-name", "search");
+        System.setProperty("search.websiteUrl", "http://localhost:9999/");
+
+        searchResponse = new QueryResponse(
+                new SearchSpecification(new SearchQuery(), List.of(), "", "test",
+                        SpecificationLimit.none(),
+                        SpecificationLimit.none(),
+                        SpecificationLimit.none(),
+                        SpecificationLimit.none(),
+                        new QueryLimits(10, 20, 3, 4),
+                        QueryStrategy.AUTO,
+                        ResultRankingParameters.sensibleDefaults()
+                        ),
+                results,
+                List.of(),
+                List.of(),
+                null
+        );
+    }
+
+    @Test
+    public void run() {
+        if (!Boolean.getBoolean("runPaperDoll")) {
+            return;
+        }
+
+        var injector = Guice.createInjector(
+                new ServiceConfigurationModule(ServiceId.Search),
+                new SearchModule(),
+                this);
+
+        injector.getInstance(SearchService.class);
+
+        registerSearchResult("https://www.example.com/foo", "Foo", "Lorem ipsum dolor sit amet", Set.of(), 0.5, 0.5, ~0L);
+        registerSearchResult("https://www.example2.com/bar", "Bar", "Some text goes here", Set.of(), 0.5, 0.5, 1L);
+
+        for (;;);
+    }
+
+    @SneakyThrows
+    public void configure() {
+        var serviceRegistry = Mockito.mock(ServiceRegistryIf.class);
+        when(serviceRegistry.registerService(any(), any(), any())).thenReturn(new ServiceEndpoint("localhost", 9999));
+
+        bind(ServiceRegistryIf.class).toInstance(serviceRegistry);
+        bind(HikariDataSource.class).toInstance(dataSource);
+
+        var qsMock = Mockito.mock(QueryClient.class);
+        when(qsMock.search(any())).thenReturn(searchResponse);
+        bind(QueryClient.class).toInstance(qsMock);
+    }
+
+}

--- a/code/services-application/search-service/test/nu/marginalia/search/paperdoll/SearchServicePaperDoll.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/paperdoll/SearchServicePaperDoll.java
@@ -33,10 +33,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -147,6 +144,7 @@ public class SearchServicePaperDoll extends AbstractModule {
 
         registerSearchResult("https://www.example.com/foo", "Foo", "Lorem ipsum dolor sit amet", Set.of(), 0.5, 0.5, ~0L);
         registerSearchResult("https://www.example2.com/bar", "Bar", "Some text goes here", Set.of(), 0.5, 0.5, 1L);
+        registerSearchResult("https://www.example3.com/baz", "All HTML Features", "This one's got every feature", EnumSet.allOf(HtmlFeature.class), 0.5, 0.5, 1L);
 
         for (;;);
     }

--- a/code/services-core/control-service/resources/templates/control/actions.hdb
+++ b/code/services-core/control-service/resources/templates/control/actions.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/actor-details.hdb
+++ b/code/services-core/control-service/resources/templates/control/actor-details.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/app/api-keys.hdb
+++ b/code/services-core/control-service/resources/templates/control/app/api-keys.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/app/blacklist.hdb
+++ b/code/services-core/control-service/resources/templates/control/app/blacklist.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/app/domain-complaints.hdb
+++ b/code/services-core/control-service/resources/templates/control/app/domain-complaints.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/app/review-random-domains.hdb
+++ b/code/services-core/control-service/resources/templates/control/app/review-random-domains.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/app/search-to-ban.hdb
+++ b/code/services-core/control-service/resources/templates/control/app/search-to-ban.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/error.hdb
+++ b/code/services-core/control-service/resources/templates/control/error.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service: Error</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/index.hdb
+++ b/code/services-core/control-service/resources/templates/control/index.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/node/node-actions.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-actions.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-actors.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-actors.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-config.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-config.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-overview.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-overview.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-storage-conf.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-storage-conf.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-storage-details.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-storage-details.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/node-storage-list.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/node-storage-list.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Node {{node.id}}</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/node/nodes-list.hdb
+++ b/code/services-core/control-service/resources/templates/control/node/nodes-list.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/partials/head-includes.hdb
+++ b/code/services-core/control-service/resources/templates/control/partials/head-includes.hdb
@@ -6,4 +6,14 @@
 body {
     border: {{{global-context.appBorder}}};
 }
+
+.screenreader-only {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}
+
 </style>

--- a/code/services-core/control-service/resources/templates/control/partials/nav.hdb
+++ b/code/services-core/control-service/resources/templates/control/partials/nav.hdb
@@ -1,3 +1,6 @@
+<div class="screenreader-only">
+    <a href="#content-begin">Skip to main content</a>
+</div>
 
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
 	<div class="container-fluid">
@@ -48,3 +51,4 @@
 	    </div>
 	</div>
 </nav>
+<a id="content-begin"></a>

--- a/code/services-core/control-service/resources/templates/control/redirect-ok.hdb
+++ b/code/services-core/control-service/resources/templates/control/redirect-ok.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/code/services-core/control-service/resources/templates/control/sys/aborted-processes.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/aborted-processes.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/data-sets.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/data-sets.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/domain-ranking-sets.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/domain-ranking-sets.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/events.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/events.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/message-queue.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/message-queue.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/new-domain-ranking-set.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/new-domain-ranking-set.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/new-message.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/new-message.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 <head>
 <title>Message Queue | New Message</title>
 {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/service-by-id.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/service-by-id.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/sys-actions.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/sys-actions.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Control Service: Actions</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/sys/update-domain-ranking-set.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/update-domain-ranking-set.hdb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
     <title>Control Service</title>
     {{> control/partials/head-includes }}

--- a/code/services-core/control-service/resources/templates/control/sys/update-message-state.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/update-message-state.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Update ID</title></head>
 <body>

--- a/code/services-core/control-service/resources/templates/control/sys/view-message.hdb
+++ b/code/services-core/control-service/resources/templates/control/sys/view-message.hdb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en-US">
 {{> control/partials/head-includes }}
 <head><title>Message Queue | New Message</title></head>
 <body>


### PR DESCRIPTION
The project was given an accessibility quickscan by HAN University.  A number of issues were found, and the changeset addresses them. 

Also added was a mockup for the search service, to avoid having to bring up an entire system for interacting with the service when changing stylesheets etc.  This can be started with `./gradlew paperDoll` and accessed at port 9999 once it starts.  It's still a bit slow to start but much faster than a full build and deploy. 

[HAN Accessibility Report Marginalia Search.pdf](https://github.com/MarginaliaSearch/MarginaliaSearch/files/15209264/HAN.Accessibility.Report.Marginalia.Search.pdf)
