### PR TITLE
Add pagination support for the search results

### DIFF
--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/QueryParams.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/QueryParams.java
@@ -4,6 +4,7 @@ import nu.marginalia.api.searchquery.model.results.ResultRankingParameters;
 import nu.marginalia.index.query.limit.QueryLimits;
 import nu.marginalia.index.query.limit.QueryStrategy;
 import nu.marginalia.index.query.limit.SpecificationLimit;
+
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -23,7 +24,8 @@ public record QueryParams(
         QueryLimits limits,
         String identifier,
         QueryStrategy queryStrategy,
-        ResultRankingParameters.TemporalBias temporalBias
+        ResultRankingParameters.TemporalBias temporalBias,
+        int page
 )
 {
     public QueryParams(String query, QueryLimits limits, String identifier) {
@@ -40,7 +42,8 @@ public record QueryParams(
                 limits,
                 identifier,
                 QueryStrategy.AUTO,
-                ResultRankingParameters.TemporalBias.NONE
+                ResultRankingParameters.TemporalBias.NONE,
+                1 // page
                 );
     }
 }

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/QueryResponse.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/QueryResponse.java
@@ -11,6 +11,8 @@ public record QueryResponse(SearchSpecification specs,
                             List<DecoratedSearchResultItem> results,
                             List<String> searchTermsHuman,
                             List<String> problems,
+                            int currentPage,
+                            int totalPages,
                             @Nullable String domain)
 {
     public Set<String> getAllKeywords() {

--- a/code/functions/search-query/api/src/main/protobuf/query-api.proto
+++ b/code/functions/search-query/api/src/main/protobuf/query-api.proto
@@ -30,6 +30,8 @@ message RpcQsQuery {
   string searchSetIdentifier = 14;
   string queryStrategy = 15;      // Named query configuration
   RpcTemporalBias temporalBias = 16;
+
+  RpcQsQueryPagination pagination = 17;
 }
 
 /* Query service query response */
@@ -39,6 +41,19 @@ message RpcQsResponse {
   repeated string searchTermsHuman = 3;
   repeated string problems = 4;
   string domain = 5;
+
+  RpcQsResultPagination pagination = 6;
+}
+
+message RpcQsQueryPagination {
+  int32 page = 1;
+  int32 pageSize = 2;
+}
+
+message RpcQsResultPagination {
+  int32 page = 1;
+  int32 pageSize = 2;
+  int32 totalResults = 3;
 }
 
 message RpcTemporalBias {

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
@@ -49,6 +49,7 @@ public class QueryGRPCService extends QueryApiGrpc.QueryApiImplBase {
                     .labels(Integer.toString(request.getQueryLimits().getTimeoutMs()),
                             Integer.toString(request.getQueryLimits().getResultsTotal()))
                     .time(() -> {
+
                 var params = QueryProtobufCodec.convertRequest(request);
                 var query = queryFactory.createQuery(params, ResultRankingParameters.sensibleDefaults());
 
@@ -68,7 +69,8 @@ public class QueryGRPCService extends QueryApiGrpc.QueryApiImplBase {
                         .addAllResults(response.results())
                         .setPagination(
                                 RpcQsResultPagination.newBuilder()
-                                        .setPage(response.page())
+                                        .setPage(requestPagination.getPage())
+                                        .setPageSize(requestPagination.getPageSize())
                                         .setTotalResults(response.totalResults())
                         )
                         .setSpecs(indexRequest)

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
@@ -8,13 +8,13 @@ import io.prometheus.client.Histogram;
 import nu.marginalia.api.searchquery.*;
 import nu.marginalia.api.searchquery.model.query.ProcessedQuery;
 import nu.marginalia.api.searchquery.model.query.QueryParams;
+import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
 import nu.marginalia.api.searchquery.model.results.ResultRankingParameters;
 import nu.marginalia.index.api.IndexClient;
-import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
 
 @Singleton
 public class QueryGRPCService extends QueryApiGrpc.QueryApiImplBase {
@@ -54,12 +54,23 @@ public class QueryGRPCService extends QueryApiGrpc.QueryApiImplBase {
 
                 var indexRequest = QueryProtobufCodec.convertQuery(request, query);
 
+                var requestPagination = request.getPagination();
+
+                IndexClient.Pagination pagination = new IndexClient.Pagination(
+                        requestPagination.getPage(),
+                        requestPagination.getPageSize());
+
                 // Execute the query on the index partitions
-                List<RpcDecoratedResultItem> bestItems = indexClient.executeQueries(indexRequest);
+                IndexClient.AggregateQueryResponse response = indexClient.executeQueries(indexRequest, pagination);
 
                  // Convert results to response and send it back
                 var responseBuilder = RpcQsResponse.newBuilder()
-                        .addAllResults(bestItems)
+                        .addAllResults(response.results())
+                        .setPagination(
+                                RpcQsResultPagination.newBuilder()
+                                        .setPage(response.page())
+                                        .setTotalResults(response.totalResults())
+                        )
                         .setSpecs(indexRequest)
                         .addAllSearchTermsHuman(query.searchTermsHuman);
 
@@ -77,18 +88,22 @@ public class QueryGRPCService extends QueryApiGrpc.QueryApiImplBase {
     }
 
     public record DetailedDirectResult(ProcessedQuery processedQuery,
-                                       List<DecoratedSearchResultItem> result) {}
+                                       List<DecoratedSearchResultItem> result,
+                                       int totalResults) {}
 
     /** Local query execution, without GRPC. */
     public DetailedDirectResult executeDirect(
             String originalQuery,
             QueryParams params,
+            IndexClient.Pagination pagination,
             ResultRankingParameters rankingParameters) {
 
         var query = queryFactory.createQuery(params, rankingParameters);
-        var items = indexClient.executeQueries(QueryProtobufCodec.convertQuery(originalQuery, query));
+        IndexClient.AggregateQueryResponse response = indexClient.executeQueries(QueryProtobufCodec.convertQuery(originalQuery, query), pagination);
 
-        return new DetailedDirectResult(query, Lists.transform(items, QueryProtobufCodec::convertQueryResult));
+        return new DetailedDirectResult(query,
+                Lists.transform(response.results(), QueryProtobufCodec::convertQueryResult),
+                response.totalResults());
     }
 
 }

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Singleton
 public class SearchOperator {
@@ -132,6 +133,14 @@ public class SearchOperator {
 
         List<String> problems = getProblems(evalResult, queryResults, queryResponse);
 
+        List<DecoratedSearchResults.Page> resultPages = IntStream.rangeClosed(1, queryResponse.totalPages())
+                .mapToObj(number -> new DecoratedSearchResults.Page(
+                        number,
+                        number == userParams.page(),
+                        userParams.withPage(number).renderUrl(websiteUrl)
+                ))
+                .toList();
+
         // Return the results to the user
         return DecoratedSearchResults.builder()
                 .params(userParams)
@@ -141,6 +150,7 @@ public class SearchOperator {
                 .filters(new SearchFilters(websiteUrl, userParams))
                 .focusDomain(focusDomain)
                 .focusDomainId(focusDomainId)
+                .resultPages(resultPages)
                 .build();
     }
 

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchQueryParamFactory.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchQueryParamFactory.java
@@ -36,7 +36,8 @@ public class SearchQueryParamFactory {
                 new QueryLimits(5, 100, 200, 8192),
                 profile.searchSetIdentifier.name(),
                 userParams.strategy(),
-                userParams.temporalBias()
+                userParams.temporalBias(),
+                userParams.page()
         );
 
     }
@@ -56,7 +57,8 @@ public class SearchQueryParamFactory {
                 new QueryLimits(count, count, 100, 512),
                 SearchSetIdentifier.NONE.name(),
                 QueryStrategy.AUTO,
-                ResultRankingParameters.TemporalBias.NONE
+                ResultRankingParameters.TemporalBias.NONE,
+                1
         );
     }
 
@@ -75,7 +77,8 @@ public class SearchQueryParamFactory {
                 new QueryLimits(100, 100, 100, 512),
                 SearchSetIdentifier.NONE.name(),
                 QueryStrategy.AUTO,
-                ResultRankingParameters.TemporalBias.NONE
+                ResultRankingParameters.TemporalBias.NONE,
+                1
         );
     }
 
@@ -94,7 +97,8 @@ public class SearchQueryParamFactory {
                 new QueryLimits(100, 100, 100, 512),
                 SearchSetIdentifier.NONE.name(),
                 QueryStrategy.AUTO,
-                ResultRankingParameters.TemporalBias.NONE
+                ResultRankingParameters.TemporalBias.NONE,
+                1
         );
     }
 }

--- a/code/services-application/search-service/java/nu/marginalia/search/command/SearchParameters.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/command/SearchParameters.java
@@ -5,9 +5,11 @@ import nu.marginalia.api.searchquery.model.results.ResultRankingParameters;
 import nu.marginalia.index.query.limit.QueryStrategy;
 import nu.marginalia.index.query.limit.SpecificationLimit;
 import nu.marginalia.search.model.SearchProfile;
+import spark.Request;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static nu.marginalia.search.command.SearchRecentParameter.RECENT;
 
@@ -17,40 +19,60 @@ public record SearchParameters(String query,
                                SearchRecentParameter recent,
                                SearchTitleParameter searchTitle,
                                SearchAdtechParameter adtech,
-                               boolean poisonResults,
-                               boolean newFilter
+                               boolean newFilter,
+                               int page
                                ) {
+
+    public SearchParameters(String queryString, Request request) {
+        this(
+                queryString,
+                SearchProfile.getSearchProfile(request.queryParams("profile")),
+                SearchJsParameter.parse(request.queryParams("js")),
+                SearchRecentParameter.parse(request.queryParams("recent")),
+                SearchTitleParameter.parse(request.queryParams("searchTitle")),
+                SearchAdtechParameter.parse(request.queryParams("adtech")),
+                "true".equals(request.queryParams("newfilter")),
+                Integer.parseInt(Objects.requireNonNullElse(request.queryParams("page"), "1"))
+            );
+    }
+
     public String profileStr() {
         return profile.filterId;
     }
 
     public SearchParameters withProfile(SearchProfile profile) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, true, page);
     }
 
     public SearchParameters withJs(SearchJsParameter js) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, true, page);
     }
     public SearchParameters withAdtech(SearchAdtechParameter adtech) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, true, page);
     }
 
     public SearchParameters withRecent(SearchRecentParameter recent) {
-        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, poisonResults, true);
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, true, page);
     }
 
     public SearchParameters withTitle(SearchTitleParameter title) {
-        return new SearchParameters(query, profile, js, recent, title, adtech, poisonResults, true);
+        return new SearchParameters(query, profile, js, recent, title, adtech, true, page);
+    }
+
+    public SearchParameters withPage(int page) {
+        return new SearchParameters(query, profile, js, recent, searchTitle, adtech, false, page);
     }
 
     public String renderUrl(WebsiteUrl baseUrl) {
-        String path = String.format("/search?query=%s&profile=%s&js=%s&adtech=%s&recent=%s&searchTitle=%s&newfilter=true",
+        String path = String.format("/search?query=%s&profile=%s&js=%s&adtech=%s&recent=%s&searchTitle=%s&newfilter=%s&page=%d",
                 URLEncoder.encode(query, StandardCharsets.UTF_8),
                 URLEncoder.encode(profile.filterId, StandardCharsets.UTF_8),
                 URLEncoder.encode(js.value, StandardCharsets.UTF_8),
                 URLEncoder.encode(adtech.value, StandardCharsets.UTF_8),
                 URLEncoder.encode(recent.value, StandardCharsets.UTF_8),
-                URLEncoder.encode(searchTitle.value, StandardCharsets.UTF_8)
+                URLEncoder.encode(searchTitle.value, StandardCharsets.UTF_8),
+                Boolean.valueOf(newFilter).toString(),
+                page
                 );
 
         return baseUrl.withPath(path);

--- a/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/DecoratedSearchResults.java
@@ -25,6 +25,10 @@ public class DecoratedSearchResults {
     private final int focusDomainId;
     private final SearchFilters filters;
 
+    private final List<Page> resultPages;
+
+    public record Page(int number, boolean current, String href) {}
+
     // These are used by the search form, they look unused in the IDE but are used by the mustache template,
     // DO NOT REMOVE THEM
     public int getResultCount() { return results.size(); }
@@ -34,5 +38,7 @@ public class DecoratedSearchResults {
     public String getAdtech() { return params.adtech().value; }
     public String getRecent() { return params.recent().value; }
     public String getSearchTitle() { return params.searchTitle().value; }
+    public int page() { return params.page(); }
     public Boolean isNewFilter() { return params.newFilter(); }
+
 }

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchQueryService.java
@@ -3,8 +3,8 @@ package nu.marginalia.search.svc;
 import com.google.inject.Inject;
 import lombok.SneakyThrows;
 import nu.marginalia.WebsiteUrl;
-import nu.marginalia.search.command.*;
-import nu.marginalia.search.model.SearchProfile;
+import nu.marginalia.search.command.CommandEvaluator;
+import nu.marginalia.search.command.SearchParameters;
 import nu.marginalia.search.exceptions.RedirectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,15 +52,7 @@ public class SearchQueryService {
                 throw new RedirectException(websiteUrl.url());
             }
 
-            return new SearchParameters(queryParam.trim(),
-                    SearchProfile.getSearchProfile(request.queryParams("profile")),
-                    SearchJsParameter.parse(request.queryParams("js")),
-                    SearchRecentParameter.parse(request.queryParams("recent")),
-                    SearchTitleParameter.parse(request.queryParams("searchTitle")),
-                    SearchAdtechParameter.parse(request.queryParams("adtech")),
-                    "1".equals(request.headers("X-Poison-Results")),
-                    "true".equals(request.queryParams("newfilter"))
-            );
+            return new SearchParameters(queryParam.trim(), request);
         }
         catch (Exception ex) {
             // Bots keep sending bad requests, suppress the error otherwise it will

--- a/code/services-application/search-service/resources/static/search/serp.scss
+++ b/code/services-application/search-service/resources/static/search/serp.scss
@@ -794,6 +794,25 @@ footer {
   }
 }
 
+.page-link {
+  padding-top: 0.25ch;
+  padding-bottom: 0.25ch;
+  padding-left: 0.5ch;
+  padding-right: 0.5ch;
+  margin-right: 0.5ch;
+
+  font-size: 12pt;
+  border: 1px solid var(--clr-border);
+  background-color: var(--clr-bg-highlight);
+  color: var(--clr-text-ui) !important;
+  text-decoration: none;
+}
+
+.page-link.active {
+  border: 1px solid var(--clr-text-ui);
+  background-color: var(--clr-bg-ui);
+}
+
 // The search results page is very confusing on text-based browsers, so we add a hr to separate the search results.  This is
 // hidden on modern browsers via CSS.
 

--- a/code/services-application/search-service/resources/templates/search/parts/search-form.hdb
+++ b/code/services-application/search-service/resources/templates/search/parts/search-form.hdb
@@ -4,7 +4,7 @@
             Search The Internet
         </h1>
         <div id="suggestions-anchor"></div>
-        <input autofocus type="text" id="query" name="query" placeholder="Search..." value="{{query}}">
+        <input {{#unless query}}autofocus{{/unless}} type="text" id="query" name="query" placeholder="Search..." value="{{query}}">
         <input type="hidden" name="js" value="{{js}}">
         <input type="hidden" name="adtech" value="{{adtech}}">
         <input type="hidden" name="searchTitle" value="{{searchTitle}}">

--- a/code/services-application/search-service/resources/templates/search/search-results.hdb
+++ b/code/services-application/search-service/resources/templates/search/search-results.hdb
@@ -53,6 +53,12 @@
             {{/with}}
             {{/if}}
         {{/each}}
+
+        <nav aria-label="pagination">
+        {{#each resultPages}}
+            <a {{#unless current}}href="{{{href}}}"{{/unless}} class="page-link {{#if current}}active{{/if}}">{{number}}</a>
+        {{/each}}
+        </nav>
     </section>
 
     {{#with filters}}

--- a/code/services-core/query-service/resources/templates/search.hdb
+++ b/code/services-core/query-service/resources/templates/search.hdb
@@ -25,6 +25,20 @@
     <p>{{description}}</p>
 </div>
 {{/each}}
+<nav aria-label="pagination">
+    <ul class="pagination">
+        {{#each pages}}
+            <form action="/search">
+                <input type="hidden" name="q" value="{{query}}">
+                <input type="hidden" name="page" value="{{number}}">
+                <li class="page-item {{#if current}}active{{/if}}"><input type="submit" class="page-link" value="{{number}}"></li>
+            </form>
+        {{/each}}
+    </ul>
+</nav>
+{{#each pages}}
+
+{{/each}}
 {{/if}}
 </div>
 </body>


### PR DESCRIPTION
This PR adds pagination support for the search results.  For now we only allow pagination among the "overfetch" caused by having multiple index nodes, this should result in up to 9 pages in production.