### PR TITLE
Process pdf files

### DIFF
--- a/code/common/model/java/nu/marginalia/model/DocumentFormat.java
+++ b/code/common/model/java/nu/marginalia/model/DocumentFormat.java
@@ -1,7 +1,7 @@
-package nu.marginalia.model.html;
+package nu.marginalia.model;
 
 // This class really doesn't belong anywhere, but will squat here for now
-public enum HtmlStandard {
+public enum DocumentFormat {
     PLAIN(0, 1),
     PDF(0, 1),
     UNKNOWN(0, 1),
@@ -15,7 +15,7 @@ public enum HtmlStandard {
     /** Used to tune quality score */
     public final double scale;
 
-    HtmlStandard(double offset, double scale) {
+    DocumentFormat(double offset, double scale) {
         this.offset = offset;
         this.scale = scale;
     }

--- a/code/common/model/java/nu/marginalia/model/DocumentFormat.java
+++ b/code/common/model/java/nu/marginalia/model/DocumentFormat.java
@@ -1,23 +1,24 @@
 package nu.marginalia.model;
 
-// This class really doesn't belong anywhere, but will squat here for now
 public enum DocumentFormat {
-    PLAIN(0, 1),
-    PDF(0, 1),
-    UNKNOWN(0, 1),
-    HTML123(0, 1),
-    HTML4(-0.1, 1.05),
-    XHTML(-0.1, 1.05),
-    HTML5(0.5, 1.1);
+    PLAIN(0, 1, "text"),
+    PDF(0, 1, "pdf"),
+    UNKNOWN(0, 1, "???"),
+    HTML123(0, 1, "html"),
+    HTML4(-0.1, 1.05, "html"),
+    XHTML(-0.1, 1.05, "html"),
+    HTML5(0.5, 1.1, "html");
 
     /** Used to tune quality score */
     public final double offset;
     /** Used to tune quality score */
     public final double scale;
+    public final String shortFormat;
 
-    DocumentFormat(double offset, double scale) {
+    DocumentFormat(double offset, double scale, String shortFormat) {
         this.offset = offset;
         this.scale = scale;
+        this.shortFormat = shortFormat;
     }
 
 }

--- a/code/common/model/java/nu/marginalia/model/crawl/HtmlFeature.java
+++ b/code/common/model/java/nu/marginalia/model/crawl/HtmlFeature.java
@@ -28,6 +28,8 @@ public enum HtmlFeature {
 
     GA_SPAM("special:gaspam"),
 
+    PDF("format:pdf"),
+
     /** For fingerprinting and ranking */
     OPENGRAPH("special:opengraph"),
     OPENGRAPH_IMAGE("special:opengraph:image"),

--- a/code/common/model/java/nu/marginalia/model/html/HtmlStandard.java
+++ b/code/common/model/java/nu/marginalia/model/html/HtmlStandard.java
@@ -3,6 +3,7 @@ package nu.marginalia.model.html;
 // This class really doesn't belong anywhere, but will squat here for now
 public enum HtmlStandard {
     PLAIN(0, 1),
+    PDF(0, 1),
     UNKNOWN(0, 1),
     HTML123(0, 1),
     HTML4(-0.1, 1.05),

--- a/code/common/model/java/nu/marginalia/model/idx/DocumentFlags.java
+++ b/code/common/model/java/nu/marginalia/model/idx/DocumentFlags.java
@@ -9,7 +9,7 @@ public enum DocumentFlags {
     GeneratorForum,
     GeneratorWiki,
     Sideloaded,
-    Unused7,
+    PdfFile,
     Unused8,
     ;
 

--- a/code/common/service/resources/log4j2-json.xml
+++ b/code/common/service/resources/log4j2-json.xml
@@ -39,7 +39,8 @@
     </Appenders>
     <Loggers>
         <Logger name="org.apache.zookeeper" level="WARN" />
-
+        <Logger name="org.apache.pdfbox" level="ERROR" />
+        <Logger name="org.apache.fontbox.ttf" level="ERROR" />
         <Root level="info">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="ProcessConsole"/>

--- a/code/common/service/resources/log4j2-prod.xml
+++ b/code/common/service/resources/log4j2-prod.xml
@@ -72,7 +72,8 @@
     </Appenders>
     <Loggers>
         <Logger name="org.apache.zookeeper" level="WARN" />
-
+        <Logger name="org.apache.pdfbox" level="ERROR" />
+        <Logger name="org.apache.fontbox.ttf" level="ERROR" />
         <Root level="info">
             <AppenderRef ref="ConsoleInfo"/>
             <AppenderRef ref="ConsoleWarn"/>

--- a/code/common/service/resources/log4j2-test.xml
+++ b/code/common/service/resources/log4j2-test.xml
@@ -37,7 +37,8 @@
     </Appenders>
     <Loggers>
         <Logger name="org.apache.zookeeper" level="WARN" />
-
+        <Logger name="org.apache.pdfbox" level="ERROR" />
+        <Logger name="org.apache.fontbox.ttf" level="ERROR" />
         <Root level="info">
             <AppenderRef ref="ConsoleInfo"/>
             <AppenderRef ref="ConsoleWarn"/>

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/results/DecoratedSearchResultItem.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/results/DecoratedSearchResultItem.java
@@ -1,6 +1,7 @@
 package nu.marginalia.api.searchquery.model.results;
 
 import nu.marginalia.api.searchquery.model.results.debug.ResultRankingDetails;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import org.jetbrains.annotations.NotNull;
 
@@ -160,5 +161,15 @@ public class DecoratedSearchResultItem implements Comparable<DecoratedSearchResu
 
     public String toString() {
         return "DecoratedSearchResultItem(rawIndexResult=" + this.getRawIndexResult() + ", url=" + this.getUrl() + ", title=" + this.getTitle() + ", description=" + this.getDescription() + ", urlQuality=" + this.getUrlQuality() + ", format=" + this.getFormat() + ", features=" + this.getFeatures() + ", pubYear=" + this.getPubYear() + ", dataHash=" + this.getDataHash() + ", wordsTotal=" + this.getWordsTotal() + ", bestPositions=" + this.getBestPositions() + ", rankingScore=" + this.getRankingScore() + ", resultsFromDomain=" + this.getResultsFromDomain() + ", rankingDetails=" + this.getRankingDetails() + ")";
+    }
+
+    public String getShortFormat() {
+        try {
+            var df = DocumentFormat.valueOf(format);
+            return df.shortFormat;
+        }
+        catch (IllegalArgumentException e) {
+            return DocumentFormat.UNKNOWN.shortFormat;
+        }
     }
 }

--- a/code/processes/converting-process/build.gradle
+++ b/code/processes/converting-process/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation libs.jwarc
 
     implementation libs.jsoup
+    implementation libs.pdfbox
 
     implementation libs.guava
     implementation dependencies.create(libs.guice.get()) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/model/ProcessedDocumentDetails.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/model/ProcessedDocumentDetails.java
@@ -1,8 +1,8 @@
 package nu.marginalia.converting.model;
 
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.HtmlFeature;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentMetadata;
 
 import javax.annotation.Nullable;
@@ -21,7 +21,7 @@ public class ProcessedDocumentDetails {
     public long hashCode;
 
     public Set<HtmlFeature> features;
-    public HtmlStandard standard;
+    public DocumentFormat format;
 
     public List<EdgeUrl> linksInternal;
     public List<EdgeUrl> linksExternal;
@@ -30,6 +30,6 @@ public class ProcessedDocumentDetails {
     public GeneratorType generator;
 
     public String toString() {
-        return "ProcessedDocumentDetails(title=" + this.title + ", description=" + this.description + ", pubYear=" + this.pubYear + ", length=" + this.length + ", quality=" + this.quality + ", hashCode=" + this.hashCode + ", features=" + this.features + ", standard=" + this.standard + ", linksInternal=" + this.linksInternal + ", linksExternal=" + this.linksExternal + ", metadata=" + this.metadata + ", generator=" + this.generator + ")";
+        return "ProcessedDocumentDetails(title=" + this.title + ", description=" + this.description + ", pubYear=" + this.pubYear + ", length=" + this.length + ", quality=" + this.quality + ", hashCode=" + this.hashCode + ", features=" + this.features + ", standard=" + this.format + ", linksInternal=" + this.linksInternal + ", linksExternal=" + this.linksExternal + ", metadata=" + this.metadata + ", generator=" + this.generator + ")";
     }
 }

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/DocumentProcessor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/DocumentProcessor.java
@@ -7,6 +7,7 @@ import nu.marginalia.converting.model.DisqualifiedException;
 import nu.marginalia.converting.model.ProcessedDocument;
 import nu.marginalia.converting.processor.plugin.AbstractDocumentProcessorPlugin;
 import nu.marginalia.converting.processor.plugin.HtmlDocumentProcessorPlugin;
+import nu.marginalia.converting.processor.plugin.PdfDocumentProcessorPlugin;
 import nu.marginalia.converting.processor.plugin.PlainTextDocumentProcessorPlugin;
 import nu.marginalia.keyword.LinkTexts;
 import nu.marginalia.model.EdgeDomain;
@@ -33,7 +34,8 @@ public class DocumentProcessor {
     private static final Set<String> acceptedContentTypes = Set.of("application/xhtml+xml",
             "application/xhtml",
             "text/html",
-            "text/plain");
+            "text/plain",
+            "application/pdf");
 
 
     private final List<AbstractDocumentProcessorPlugin> processorPlugins = new ArrayList<>();
@@ -42,12 +44,14 @@ public class DocumentProcessor {
     @Inject
     public DocumentProcessor(HtmlDocumentProcessorPlugin htmlDocumentProcessorPlugin,
                              PlainTextDocumentProcessorPlugin plainTextDocumentProcessorPlugin,
+                             PdfDocumentProcessorPlugin pdfDocumentProcessorPlugin,
                              AnchorTextKeywords anchorTextKeywords)
     {
         this.anchorTextKeywords = anchorTextKeywords;
 
         processorPlugins.add(htmlDocumentProcessorPlugin);
         processorPlugins.add(plainTextDocumentProcessorPlugin);
+        processorPlugins.add(pdfDocumentProcessorPlugin);
     }
 
     public ProcessedDocument process(CrawledDocument crawledDocument,

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/logic/DocumentValuator.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/logic/DocumentValuator.java
@@ -2,9 +2,9 @@ package nu.marginalia.converting.processor.logic;
 
 import crawlercommons.utils.Strings;
 import nu.marginalia.converting.model.DisqualifiedException;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -17,7 +17,7 @@ import java.util.Set;
 public class DocumentValuator {
 
     public double getQuality(CrawledDocument crawledDocument,
-                             HtmlStandard htmlStandard,
+                             DocumentFormat htmlStandard,
                              Document parsedDocument,
                              int textLength) throws DisqualifiedException {
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/logic/HtmlStandardExtractor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/logic/HtmlStandardExtractor.java
@@ -1,7 +1,7 @@
 package nu.marginalia.converting.processor.logic;
 
 import com.google.common.base.Strings;
-import nu.marginalia.model.html.HtmlStandard;
+import nu.marginalia.model.DocumentFormat;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.DocumentType;
 import org.slf4j.Logger;
@@ -12,54 +12,54 @@ public class HtmlStandardExtractor {
 
     private static final Logger logger = LoggerFactory.getLogger(HtmlStandardExtractor.class);
 
-    public static HtmlStandard parseDocType(DocumentType docType) {
+    public static DocumentFormat parseDocType(DocumentType docType) {
         if (null == docType) {
-            return HtmlStandard.UNKNOWN;
+            return DocumentFormat.UNKNOWN;
         }
 
         String publicId = docType.publicId();
         if (Strings.isNullOrEmpty(publicId))
-            return HtmlStandard.HTML5;
+            return DocumentFormat.HTML5;
 
         publicId = publicId.toUpperCase();
         if (publicId.startsWith("-//SOFTQUAD SOFTWARE//DTD") && publicId.contains("HTML 4")) {
-            return HtmlStandard.HTML4;
+            return DocumentFormat.HTML4;
         }
         if (publicId.startsWith("-//SOFTQUAD SOFTWARE//DTD") && publicId.contains("HTML 3")) {
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         }
         if (publicId.startsWith("-//INTERNET/RFC XXXX//EN"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//NETSCAPE COMM. CORP"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//SQ//DTD HTML 2"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//SOFTQUAD//DTD HTML 2"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//W3O//DTD W3 HTML 2"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//IETF//DTD HTML 2"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//IETF//DTD HTML//EN"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-/W3C//DTD HTML 3"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-/W3C/DTD HTML 3"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//IETF//DTD HTML 3"))
-            return HtmlStandard.HTML123;
+            return DocumentFormat.HTML123;
         if (publicId.startsWith("-//W3C//DTD XHTML"))
-            return HtmlStandard.XHTML;
+            return DocumentFormat.XHTML;
         if (publicId.startsWith("ISO/IEC 15445:2000//DTD"))
-            return HtmlStandard.XHTML;
+            return DocumentFormat.XHTML;
         if (publicId.startsWith("-//W3C//DTD HTML"))
-            return HtmlStandard.HTML4;
+            return DocumentFormat.HTML4;
 
         logger.debug("Unknown publicID standard {}", publicId);
-        return HtmlStandard.UNKNOWN;
+        return DocumentFormat.UNKNOWN;
     }
 
-    public static HtmlStandard sniffHtmlStandard(Document parsed) {
+    public static DocumentFormat sniffHtmlStandard(Document parsed) {
         int html4Attributes = 0;
         int html5Attributes = 0;
 
@@ -73,11 +73,11 @@ public class HtmlStandardExtractor {
             html4Attributes++;
         }
         if (html5Attributes > 0) {
-            return HtmlStandard.HTML5;
+            return DocumentFormat.HTML5;
         }
         if (html4Attributes > 0) {
-            return HtmlStandard.HTML4;
+            return DocumentFormat.HTML4;
         }
-        return HtmlStandard.HTML123;
+        return DocumentFormat.HTML123;
     }
 }

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/AbstractDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/AbstractDocumentProcessorPlugin.java
@@ -7,11 +7,11 @@ import nu.marginalia.keyword.LinkTexts;
 import nu.marginalia.keyword.model.DocumentKeywordsBuilder;
 import nu.marginalia.language.filter.LanguageFilter;
 import nu.marginalia.language.model.DocumentLanguageData;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -73,7 +73,7 @@ public abstract class AbstractDocumentProcessorPlugin {
             return this;
         }
 
-        public MetaTagsBuilder addFormat(HtmlStandard standard) {
+        public MetaTagsBuilder addFormat(DocumentFormat standard) {
 
             add("format", standard);
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/HtmlDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/HtmlDocumentProcessorPlugin.java
@@ -25,12 +25,12 @@ import nu.marginalia.language.model.DocumentLanguageData;
 import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
 import nu.marginalia.link_parser.FeedExtractor;
 import nu.marginalia.link_parser.LinkParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeDomain;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentFlags;
 import nu.marginalia.model.idx.DocumentMetadata;
 import org.jsoup.nodes.Document;
@@ -137,8 +137,8 @@ public class HtmlDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin
 
 
         final int length = getLength(doc);
-        final HtmlStandard standard = getHtmlStandard(doc);
-        final double quality = documentValuator.getQuality(crawledDocument, standard, doc, length);
+        final DocumentFormat format = getDocumentFormat(doc);
+        final double quality = documentValuator.getQuality(crawledDocument, format, doc, length);
 
         if (isDisqualified(documentClass, url, quality, doc.title())) {
             throw new DisqualifiedException(DisqualificationReason.QUALITY);
@@ -152,7 +152,7 @@ public class HtmlDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin
         var ret = new ProcessedDocumentDetails();
 
         ret.length = length;
-        ret.standard = standard;
+        ret.format = format;
         ret.title = specialization.getTitle(doc, dld, crawledDocument.url);
 
         final Set<HtmlFeature> features = featureExtractor.getFeatures(url, doc, documentHeaders, dld);
@@ -161,7 +161,7 @@ public class HtmlDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin
         ret.quality = documentValuator.adjustQuality(quality, features);
         ret.hashCode = dld.localitySensitiveHashCode();
 
-        PubDate pubDate = pubDateSniffer.getPubDate(documentHeaders, url, doc, standard, true);
+        PubDate pubDate = pubDateSniffer.getPubDate(documentHeaders, url, doc, format, true);
 
         EnumSet<DocumentFlags> documentFlags = documentFlags(features, generatorParts.type());
 
@@ -180,7 +180,7 @@ public class HtmlDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin
                 .addPubDate(pubDate)
                 .addUrl(url)
                 .addFeatures(features)
-                .addFormat(standard)
+                .addFormat(format)
                 .addGenerator(generatorParts.keywords())
                 .build();
 
@@ -316,12 +316,12 @@ public class HtmlDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin
         return linkTerms;
     }
 
-    private HtmlStandard getHtmlStandard(Document doc) {
-        HtmlStandard htmlStandard = HtmlStandardExtractor.parseDocType(doc.documentType());
-        if (HtmlStandard.UNKNOWN.equals(htmlStandard)) {
+    private DocumentFormat getDocumentFormat(Document doc) {
+        DocumentFormat format = HtmlStandardExtractor.parseDocType(doc.documentType());
+        if (DocumentFormat.UNKNOWN.equals(format)) {
             return HtmlStandardExtractor.sniffHtmlStandard(doc);
         }
-        return htmlStandard;
+        return format;
     }
 
     private int getLength(Document doc) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -204,6 +204,10 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
             // <h1>...</h1><h1>...</h1> -> <h1>...</h1>
             parsed.getElementsByTag("h1").forEach(h1 -> {
+                var nextSibling = h1.nextElementSibling();
+                if (nextSibling == null || !"h1".equals(nextSibling.tagName())) {
+                    return; // Short-circuit to avoid unnecessary work
+                }
 
                 StringJoiner joiner = new StringJoiner(" ");
                 joiner.add(h1.text());

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -27,10 +27,7 @@ import org.apache.pdfbox.text.PDFTextStripper;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 
 public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin {
@@ -86,7 +83,9 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
         DocumentLanguageData dld;
         try (var doc = PDDocument.load(crawledDocument.documentBodyBytes)) {
-            dld = sentenceExtractorProvider.get().extractSentences(new PDFTextStripper().getText(doc), "");
+            String title = Objects.requireNonNullElse(doc.getDocumentInformation().getTitle(), "");
+
+            dld = sentenceExtractorProvider.get().extractSentences(new PDFTextStripper().getText(doc), title);
         }
 
         checkDocumentLanguage(dld);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -13,11 +13,11 @@ import nu.marginalia.keyword.model.DocumentKeywordsBuilder;
 import nu.marginalia.language.filter.LanguageFilter;
 import nu.marginalia.language.model.DocumentLanguageData;
 import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentFlags;
 import nu.marginalia.model.idx.DocumentMetadata;
 import org.apache.commons.lang3.StringUtils;
@@ -109,7 +109,7 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
         ret.length = documentBody.length();
 
-        ret.standard = HtmlStandard.PDF;
+        ret.format = DocumentFormat.PDF;
         ret.title = StringUtils.truncate(defaultSpecialization.getTitle(doc, dld, url.toString()), maxTitleLength);
 
         ret.quality = -5;
@@ -134,7 +134,7 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
                 .addPubDate(pubDate)
                 .addUrl(url)
                 .addFeatures(ret.features)
-                .addFormat(ret.standard)
+                .addFormat(ret.format)
                 .build();
 
         words.addAllSyntheticTerms(tagWords);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -173,6 +173,9 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
             stripper.setSortByPosition(true);
             stripper.setWordSeparator(" ");
 
+            // Increase the tolerance for line spacing to deal better with paragraphs.
+            stripper.setDropThreshold(5f);
+
             stripper.setPageStart("<div>");
             stripper.setParagraphStart("<p>");
             stripper.setParagraphEnd("</p>\n");
@@ -187,6 +190,8 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
             htmlBuilder.append("<html><body>")
                     .append(text)
                     .append("</body></html>");
+
+            System.out.println(htmlBuilder);
 
             var parsed = Jsoup.parse(htmlBuilder.toString());
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -14,6 +14,7 @@ import nu.marginalia.language.filter.LanguageFilter;
 import nu.marginalia.language.model.DocumentLanguageData;
 import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
 import nu.marginalia.model.EdgeUrl;
+import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.model.html.HtmlStandard;
@@ -102,7 +103,7 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
         ret.quality = -5;
 
-        ret.features = new HashSet<>();
+        ret.features = Set.of(HtmlFeature.PDF);
         ret.description = getDescription(doc);
         ret.hashCode = dld.localitySensitiveHashCode();
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -220,6 +220,13 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
                 }
             });
 
+            // Remove empty <p> tags
+            parsed.getElementsByTag("p").forEach(p -> {
+                if (p.childrenSize() == 0 && !p.hasText()) {
+                    p.remove();
+                }
+            });
+
             // <h1>...</h1><h1>...</h1> -> <h1>...</h1>
             parsed.getElementsByTag("h1").forEach(h1 -> {
                 var nextSibling = h1.nextElementSibling();

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -6,7 +6,6 @@ import nu.marginalia.converting.model.DisqualifiedException;
 import nu.marginalia.converting.model.ProcessedDocumentDetails;
 import nu.marginalia.converting.processor.DocumentClass;
 import nu.marginalia.converting.processor.logic.DocumentLengthLogic;
-import nu.marginalia.converting.processor.logic.PlainTextLogic;
 import nu.marginalia.converting.processor.plugin.specialization.DefaultSpecialization;
 import nu.marginalia.keyword.DocumentKeywordExtractor;
 import nu.marginalia.keyword.LinkTexts;
@@ -29,14 +28,16 @@ import org.jsoup.nodes.Document;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
 
 
 public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin {
 
     private final int maxTitleLength;
     private final DocumentKeywordExtractor keywordExtractor;
-    private final PlainTextLogic plainTextLogic = new PlainTextLogic();
     private final ThreadLocalSentenceExtractorProvider sentenceExtractorProvider;
     private final DocumentLengthLogic documentLengthLogic;
     private final DefaultSpecialization defaultSpecialization;
@@ -99,7 +100,7 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
         ret.standard = HtmlStandard.PDF;
         ret.title = StringUtils.truncate(defaultSpecialization.getTitle(doc, dld, url.toString()), maxTitleLength);
 
-        ret.quality = -1;
+        ret.quality = -5;
 
         ret.features = new HashSet<>();
         ret.description = getDescription(doc);
@@ -109,8 +110,11 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
         EnumSet<DocumentFlags> documentFlags = EnumSet.of(DocumentFlags.PdfFile);
 
-        ret.metadata = new DocumentMetadata(documentLengthLogic.getEncodedAverageLength(dld),
-                pubDate.yearByte(), (int) -ret.quality, documentFlags);
+        ret.metadata = new DocumentMetadata(
+                documentLengthLogic.getEncodedAverageLength(dld),
+                pubDate.yearByte(),
+                (int) -ret.quality,
+                documentFlags);
 
         DocumentKeywordsBuilder words = keywordExtractor.extractKeywords(dld, linkTexts, url);
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -107,7 +107,7 @@ public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin 
 
         final PubDate pubDate = new PubDate(LocalDate.ofYearDay(1993, 1));
 
-        EnumSet<DocumentFlags> documentFlags = EnumSet.of(DocumentFlags.PlainText);
+        EnumSet<DocumentFlags> documentFlags = EnumSet.of(DocumentFlags.PdfFile);
 
         ret.metadata = new DocumentMetadata(documentLengthLogic.getEncodedAverageLength(dld),
                 pubDate.yearByte(), (int) -ret.quality, documentFlags);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPlugin.java
@@ -1,0 +1,141 @@
+package nu.marginalia.converting.processor.plugin;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import nu.marginalia.converting.model.DisqualifiedException;
+import nu.marginalia.converting.model.ProcessedDocumentDetails;
+import nu.marginalia.converting.processor.DocumentClass;
+import nu.marginalia.converting.processor.logic.DocumentLengthLogic;
+import nu.marginalia.converting.processor.logic.PlainTextLogic;
+import nu.marginalia.converting.util.LineUtils;
+import nu.marginalia.keyword.DocumentKeywordExtractor;
+import nu.marginalia.keyword.LinkTexts;
+import nu.marginalia.keyword.model.DocumentKeywordsBuilder;
+import nu.marginalia.language.filter.LanguageFilter;
+import nu.marginalia.language.model.DocumentLanguageData;
+import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
+import nu.marginalia.model.EdgeUrl;
+import nu.marginalia.model.crawl.PubDate;
+import nu.marginalia.model.crawldata.CrawledDocument;
+import nu.marginalia.model.html.HtmlStandard;
+import nu.marginalia.model.idx.DocumentFlags;
+import nu.marginalia.model.idx.DocumentMetadata;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+
+
+public class PdfDocumentProcessorPlugin extends AbstractDocumentProcessorPlugin {
+
+    private final int maxTitleLength;
+    private final DocumentKeywordExtractor keywordExtractor;
+    private final PlainTextLogic plainTextLogic = new PlainTextLogic();
+    private final ThreadLocalSentenceExtractorProvider sentenceExtractorProvider;
+    private final DocumentLengthLogic documentLengthLogic;
+
+
+    @Inject
+    public PdfDocumentProcessorPlugin(@Named("max-title-length") Integer maxTitleLength,
+                                      LanguageFilter languageFilter,
+                                      ThreadLocalSentenceExtractorProvider sentenceExtractorProvider,
+                                      DocumentKeywordExtractor keywordExtractor,
+                                      DocumentLengthLogic documentLengthLogic
+                                            )
+    {
+        super(languageFilter);
+        this.sentenceExtractorProvider = sentenceExtractorProvider;
+        this.documentLengthLogic = documentLengthLogic;
+        this.maxTitleLength = maxTitleLength;
+        this.keywordExtractor = keywordExtractor;
+    }
+
+    @Override
+    public boolean isApplicable(CrawledDocument doc) {
+        String contentType = doc.contentType.toLowerCase();
+
+        if (contentType.equals("application/pdf"))
+            return true;
+        if (contentType.startsWith("application/pdf;")) // charset=blabla
+            return true;
+
+        return false;
+    }
+
+    @Override
+    public DetailsWithWords createDetails(CrawledDocument crawledDocument,
+                                          LinkTexts linkTexts,
+                                          DocumentClass documentClass)
+            throws DisqualifiedException, URISyntaxException, IOException {
+
+        String documentBody = crawledDocument.documentBody();
+
+        if (languageFilter.isBlockedUnicodeRange(documentBody)) {
+            throw new DisqualifiedException(DisqualifiedException.DisqualificationReason.LANGUAGE);
+        }
+
+        final EdgeUrl url = new EdgeUrl(crawledDocument.url);
+
+
+        DocumentLanguageData dld;
+        try (var doc = PDDocument.load(crawledDocument.documentBodyBytes)) {
+            dld = sentenceExtractorProvider.get().extractSentences(new PDFTextStripper().getText(doc), "");
+        }
+
+        checkDocumentLanguage(dld);
+
+        documentLengthLogic.validateLength(dld, 1.0);
+
+        var ret = new ProcessedDocumentDetails();
+
+        List<String> firstFewLines = LineUtils.firstNLines(documentBody, 40);
+
+        ret.length = documentBody.length();
+
+        ret.standard = HtmlStandard.PLAIN;
+        ret.title = StringUtils.truncate(plainTextLogic.getTitle(url, firstFewLines), maxTitleLength);
+
+        ret.quality = -1;
+
+        ret.features = new HashSet<>();
+        ret.description = StringUtils.truncate(plainTextLogic.getDescription(firstFewLines), 255);
+        ret.hashCode = dld.localitySensitiveHashCode();
+
+        final PubDate pubDate = new PubDate(LocalDate.ofYearDay(1993, 1));
+
+        EnumSet<DocumentFlags> documentFlags = EnumSet.of(DocumentFlags.PlainText);
+
+        ret.metadata = new DocumentMetadata(documentLengthLogic.getEncodedAverageLength(dld),
+                pubDate.yearByte(), (int) -ret.quality, documentFlags);
+
+        DocumentKeywordsBuilder words = keywordExtractor.extractKeywords(dld, linkTexts, url);
+
+        var tagWords = new MetaTagsBuilder()
+                .addPubDate(pubDate)
+                .addUrl(url)
+                .addFeatures(ret.features)
+                .addFormat(ret.standard)
+                .build();
+
+        words.addAllSyntheticTerms(tagWords);
+
+        if (pubDate.hasYear()) {
+            ret.pubYear = pubDate.year();
+        }
+
+        /* These are assumed to be populated */
+        ret.linksInternal = new ArrayList<>();
+        ret.linksExternal = new ArrayList<>();
+
+        return new DetailsWithWords(ret, words);
+    }
+
+
+}

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PlainTextDocumentProcessorPlugin.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/plugin/PlainTextDocumentProcessorPlugin.java
@@ -13,10 +13,10 @@ import nu.marginalia.keyword.LinkTexts;
 import nu.marginalia.keyword.model.DocumentKeywordsBuilder;
 import nu.marginalia.language.filter.LanguageFilter;
 import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentFlags;
 import nu.marginalia.model.idx.DocumentMetadata;
 import org.apache.commons.lang3.StringUtils;
@@ -91,7 +91,7 @@ public class PlainTextDocumentProcessorPlugin extends AbstractDocumentProcessorP
 
         ret.length = documentBody.length();
 
-        ret.standard = HtmlStandard.PLAIN;
+        ret.format = DocumentFormat.PLAIN;
         ret.title = StringUtils.truncate(plainTextLogic.getTitle(url, firstFewLines), maxTitleLength);
 
         ret.quality = -1;
@@ -113,7 +113,7 @@ public class PlainTextDocumentProcessorPlugin extends AbstractDocumentProcessorP
                 .addPubDate(pubDate)
                 .addUrl(url)
                 .addFeatures(ret.features)
-                .addFormat(ret.standard)
+                .addFormat(ret.format)
                 .build();
 
         words.addAllSyntheticTerms(tagWords);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateFromHtmlStandard.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateFromHtmlStandard.java
@@ -1,11 +1,11 @@
 package nu.marginalia.converting.processor.pubdate;
 
-import nu.marginalia.model.html.HtmlStandard;
+import nu.marginalia.model.DocumentFormat;
 
 public class PubDateFromHtmlStandard {
     /** Used to bias pub date heuristics */
-    public static int blindGuess(HtmlStandard standard) {
-        return switch (standard) {
+    public static int blindGuess(DocumentFormat format) {
+        return switch (format) {
             case PLAIN -> 1993;
             case PDF -> 2010;
             case HTML123 -> 1997;
@@ -22,8 +22,8 @@ public class PubDateFromHtmlStandard {
      * Discovering publication year involves a lot of guesswork, this helps
      * keep the guesses relatively sane.
      */
-    public static boolean isGuessPlausible(HtmlStandard standard, int year) {
-        switch (standard) {
+    public static boolean isGuessPlausible(DocumentFormat format, int year) {
+        switch (format) {
             case HTML123:
                 return year <= 2000;
             case XHTML:

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateFromHtmlStandard.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateFromHtmlStandard.java
@@ -7,6 +7,7 @@ public class PubDateFromHtmlStandard {
     public static int blindGuess(HtmlStandard standard) {
         return switch (standard) {
             case PLAIN -> 1993;
+            case PDF -> 2010;
             case HTML123 -> 1997;
             case HTML4, XHTML -> 2006;
             case HTML5 -> 2018;

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateHeuristic.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateHeuristic.java
@@ -1,14 +1,14 @@
 package nu.marginalia.converting.processor.pubdate;
 
 import nu.marginalia.converting.model.DocumentHeaders;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
 
 public interface PubDateHeuristic {
 
-    Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard);
+    Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard);
 }

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateParser.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateParser.java
@@ -1,7 +1,7 @@
 package nu.marginalia.converting.processor.pubdate;
 
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -26,7 +26,7 @@ public class PubDateParser {
                 .filter(PubDateParser::validateDate);
     }
 
-    public static Optional<PubDate> attemptParseDate(String date, HtmlStandard standard) {
+    public static Optional<PubDate> attemptParseDate(String date, DocumentFormat standard) {
         return Optional.ofNullable(date)
                 .filter(str -> str.length() >= 4 && str.length() < 32)
                 .flatMap(str ->
@@ -81,7 +81,7 @@ public class PubDateParser {
     }
 
 
-    public static Optional<PubDate> dateFromHighestYearLookingSubstringWithGuess(String maybe, HtmlStandard standard) {
+    public static Optional<PubDate> dateFromHighestYearLookingSubstringWithGuess(String maybe, DocumentFormat standard) {
         int guess = PubDateFromHtmlStandard.blindGuess(standard);
 
         var matcher = yearPattern.matcher(maybe);
@@ -135,7 +135,7 @@ public class PubDateParser {
         return (max + min) / 2;
     }
 
-    public static int guessYear(HtmlStandard standard) {
+    public static int guessYear(DocumentFormat standard) {
         // Create some jitter to avoid having documents piling up in the same four years
         // as this would make searching in those years disproportionately useless
 

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateSniffer.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/PubDateSniffer.java
@@ -2,9 +2,9 @@ package nu.marginalia.converting.processor.pubdate;
 
 import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.heuristic.*;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ public class PubDateSniffer {
         heuristics.add(new PubDateHeuristicGuessFromHtmlStandard());
     }
 
-    public PubDate getPubDate(DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard, boolean runExpensive) {
+    public PubDate getPubDate(DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard, boolean runExpensive) {
         final PubDateEffortLevel effortLevel = runExpensive ? PubDateEffortLevel.HIGH : PubDateEffortLevel.LOW;
 
         for (var heuristic : heuristics) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicDOMParsingPass1.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicDOMParsingPass1.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class PubDateHeuristicDOMParsingPass1 implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         if (effortLevel == PubDateEffortLevel.LOW)
             return Optional.empty();
 
@@ -33,9 +33,9 @@ public class PubDateHeuristicDOMParsingPass1 implements PubDateHeuristic {
 
     private static class DateExtractingNodeVisitorPass implements NodeFilter {
         public PubDate pubDate;
-        private final HtmlStandard htmlStandard;
+        private final DocumentFormat htmlStandard;
 
-        private DateExtractingNodeVisitorPass(HtmlStandard htmlStandard) {
+        private DateExtractingNodeVisitorPass(DocumentFormat htmlStandard) {
             this.htmlStandard = htmlStandard;
         }
 
@@ -135,7 +135,7 @@ public class PubDateHeuristicDOMParsingPass1 implements PubDateHeuristic {
         }
 
         private void parse(String text) {
-            if (htmlStandard == HtmlStandard.UNKNOWN) {
+            if (htmlStandard == DocumentFormat.UNKNOWN) {
                 PubDateParser
                         .dateFromHighestYearLookingSubstring(text)
                         .ifPresent(this::setPubDate);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicDOMParsingPass2.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicDOMParsingPass2.java
@@ -5,9 +5,9 @@ import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateFromHtmlStandard;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class PubDateHeuristicDOMParsingPass2 implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         if (effortLevel == PubDateEffortLevel.LOW)
             return Optional.empty();
 
@@ -33,9 +33,9 @@ public class PubDateHeuristicDOMParsingPass2 implements PubDateHeuristic {
 
     private static class DateExtractingNodeVisitor implements NodeFilter {
         public PubDate pubDate;
-        private final HtmlStandard htmlStandard;
+        private final DocumentFormat htmlStandard;
 
-        private DateExtractingNodeVisitor(HtmlStandard htmlStandard) {
+        private DateExtractingNodeVisitor(DocumentFormat htmlStandard) {
             this.htmlStandard = htmlStandard;
         }
 
@@ -73,7 +73,7 @@ public class PubDateHeuristicDOMParsingPass2 implements PubDateHeuristic {
         }
 
         private void parse(String text) {
-            if (htmlStandard == HtmlStandard.UNKNOWN) {
+            if (htmlStandard == DocumentFormat.UNKNOWN) {
                 PubDateParser
                         .dateFromHighestYearLookingSubstring(text)
                         .ifPresent(this::setPubDate);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicGuessFromHtmlStandard.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicGuessFromHtmlStandard.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,8 +14,8 @@ import java.util.Optional;
 public class PubDateHeuristicGuessFromHtmlStandard implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
-        if (htmlStandard == HtmlStandard.UNKNOWN)
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
+        if (htmlStandard == DocumentFormat.UNKNOWN)
             return Optional.empty();
 
         return Optional.of(new PubDate(null, PubDateParser.guessYear(htmlStandard)));

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5AnyTimeTag.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5AnyTimeTag.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicHtml5AnyTimeTag implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         // HTML5, alternative approach
         for (var tag : document.select("time")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("datetime"));

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5ArticleDateTag.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5ArticleDateTag.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicHtml5ArticleDateTag implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         // HTML5
         for (var tag : document.select("time[pubdate=\"pubdate\"]")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("datetime"));

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5ItempropDateTag.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicHtml5ItempropDateTag.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicHtml5ItempropDateTag implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         for (var tag : document.select("time[itemprop=\"datePublished\"]")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("content"));
             if (maybeDate.isPresent()) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicJSONLD.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicJSONLD.java
@@ -8,9 +8,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Collections;
@@ -21,7 +21,7 @@ import java.util.Optional;
 public class PubDateHeuristicJSONLD implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         for (var tag : document.select("script[type=\"application/ld+json\"]")) {
             var maybeDate = parseLdJson(tag.data())
                     .flatMap(PubDateParser::attemptParseDate);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicLastModified.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicLastModified.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.List;
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class PubDateHeuristicLastModified implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         List<String> lastModified = headers.get("last-modified");
         if (lastModified.isEmpty())
             return Optional.empty();

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicMicrodata.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicMicrodata.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicMicrodata implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
 
         for (var tag : document.select("meta[itemprop=\"datePublished\"]")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("content"));

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicOpenGraph.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicOpenGraph.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicOpenGraph implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         // OG
         for (var tag : document.select("meta[property=\"article:published_time\"]")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("content"));

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicRDFaTag.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicRDFaTag.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class PubDateHeuristicRDFaTag implements PubDateHeuristic {
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         for (var tag : document.select("meta[property=\"datePublished\"]")) {
             var maybeDate = PubDateParser.attemptParseDate(tag.attr("content"));
             if (maybeDate.isPresent()) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicUrlPatternPass1.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicUrlPatternPass1.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -21,7 +21,7 @@ public class PubDateHeuristicUrlPatternPass1 implements PubDateHeuristic {
     private static final int MIN_URL_PATTERN_YEAR = 2000;
 
     @Override
-    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, HtmlStandard htmlStandard) {
+    public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url, Document document, DocumentFormat htmlStandard) {
         final String urlString = url.path;
 
         var matcher = yearUrlPattern.matcher(urlString);

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicUrlPatternPass2.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/pubdate/heuristic/PubDateHeuristicUrlPatternPass2.java
@@ -4,9 +4,9 @@ import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.PubDateEffortLevel;
 import nu.marginalia.converting.processor.pubdate.PubDateHeuristic;
 import nu.marginalia.converting.processor.pubdate.PubDateParser;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.PubDate;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.nodes.Document;
 
 import java.util.Optional;
@@ -19,7 +19,7 @@ public class PubDateHeuristicUrlPatternPass2 implements PubDateHeuristic {
 
     @Override
     public Optional<PubDate> apply(PubDateEffortLevel effortLevel, DocumentHeaders headers, EdgeUrl url,
-                                   Document document, HtmlStandard htmlStandard) {
+                                   Document document, DocumentFormat htmlStandard) {
         final String urlString = url.path;
 
         var matcher = yearUrlPattern.matcher(urlString);

--- a/code/processes/converting-process/java/nu/marginalia/converting/sideload/SideloaderProcessing.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/sideload/SideloaderProcessing.java
@@ -8,12 +8,12 @@ import nu.marginalia.converting.model.ProcessedDocument;
 import nu.marginalia.converting.processor.DocumentClass;
 import nu.marginalia.converting.processor.plugin.HtmlDocumentProcessorPlugin;
 import nu.marginalia.keyword.LinkTexts;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawl.UrlIndexingState;
 import nu.marginalia.model.crawldata.CrawledDocument;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentFlags;
 import nu.marginalia.model.idx.DocumentMetadata;
 import nu.marginalia.model.idx.WordFlags;
@@ -83,7 +83,7 @@ public class SideloaderProcessing {
             // that we can't get from the sideloaded data since it's
             // so stripped down
 
-            ret.details.standard = HtmlStandard.HTML5;
+            ret.details.format = DocumentFormat.HTML5;
             ret.details.pubYear = pubYear;
             ret.details.features.add(HtmlFeature.JS);
             ret.details.features.add(HtmlFeature.TRACKING);

--- a/code/processes/converting-process/java/nu/marginalia/converting/sideload/stackexchange/StackexchangeSideloader.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/sideload/stackexchange/StackexchangeSideloader.java
@@ -9,13 +9,13 @@ import nu.marginalia.integration.stackexchange.sqlite.StackExchangePostsDb;
 import nu.marginalia.keyword.DocumentKeywordExtractor;
 import nu.marginalia.keyword.LinkTexts;
 import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeDomain;
 import nu.marginalia.model.EdgeUrl;
 import nu.marginalia.model.crawl.DomainIndexingState;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.crawl.UrlIndexingState;
-import nu.marginalia.model.html.HtmlStandard;
 import nu.marginalia.model.idx.DocumentFlags;
 import nu.marginalia.model.idx.DocumentMetadata;
 import nu.marginalia.model.idx.WordFlags;
@@ -165,7 +165,7 @@ public class StackexchangeSideloader implements SideloadSource {
             ret.details.description = StringUtils.truncate(doc.body().text(), 255);
             ret.details.length = 128;
 
-            ret.details.standard = HtmlStandard.HTML5;
+            ret.details.format = DocumentFormat.HTML5;
             ret.details.linksExternal = List.of();
             ret.details.linksInternal = List.of();
             ret.state = UrlIndexingState.OK;

--- a/code/processes/converting-process/java/nu/marginalia/converting/writer/ConverterBatchWriter.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/writer/ConverterBatchWriter.java
@@ -124,7 +124,7 @@ public class ConverterBatchWriter implements AutoCloseable, ConverterBatchWriter
                     document.details.title,
                     document.details.description,
                     HtmlFeature.encode(document.details.features),
-                    document.details.standard.name(),
+                    document.details.format.name(),
                     document.details.length,
                     document.details.hashCode,
                     (float) document.details.quality,

--- a/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
+++ b/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
@@ -1944,7 +1944,11 @@ public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
             return;
 
         double avgFontSize = getAverageFontSizeOfLine(line);
-        double ypos = line.getFirst().textPositions.getFirst().getY();
+
+        float ypos = getLineYPosition(line);
+        if (Float.isNaN(ypos))
+            return;
+
         boolean isHeading = avgFontSize >= headingBoundary
                 && (line.size() > 1 || line.getFirst().text.length() > 2)
                 && ypos < headingBreak;
@@ -1967,6 +1971,26 @@ public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
         if (isHeading) {
             writeHeadingEnd();
         }
+    }
+
+    /** Get the Y position of the first TextPosition in the line.
+     *
+     * @return Y position of the first TextPosition in the line,
+     *         or NaN if the line is empty or has no TextPositions
+     */
+    private float getLineYPosition(List<WordWithTextPositions> line)
+    {
+        if (line.isEmpty()) {
+            return Float.NaN;
+        }
+
+        List<TextPosition> firstTextPosition = line.getFirst().getTextPositions();
+
+        if (firstTextPosition == null || firstTextPosition.isEmpty()) {
+            return Float.NaN;
+        }
+
+        return firstTextPosition.getFirst().getY();
     }
 
     /**

--- a/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
+++ b/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
@@ -152,6 +152,8 @@ public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
     private boolean firstActualTextPosition = false;
     private String actualText = null;
 
+    private double headingBreak = -1;
+
     /**
      * The charactersByArticle is used to extract text by article divisions. For example a PDF that has two columns like
      * a newspaper, we want to extract the first column and then the second column. In this example the PDF would have 2
@@ -365,6 +367,10 @@ public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
             }
             characterListMapping.clear();
             super.processPage(page);
+
+            // Set a highest y-coordinate we'll accept as a heading position
+            headingBreak = page.getBBox().getHeight() * 0.75;
+
             writePage();
             endPage(page);
             page.removePageResourceFromCache();
@@ -1938,7 +1944,10 @@ public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
             return;
 
         double avgFontSize = getAverageFontSizeOfLine(line);
-        boolean isHeading = avgFontSize >= headingBoundary && (line.size() > 1 || line.getFirst().text.length() > 2);
+        double ypos = line.getFirst().textPositions.getFirst().getY();
+        boolean isHeading = avgFontSize >= headingBoundary
+                && (line.size() > 1 || line.getFirst().text.length() > 2)
+                && ypos < headingBreak;
 
         if (isHeading) {
             writeHeadingStart();

--- a/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
+++ b/code/processes/converting-process/java/org/apache/pdfbox/text/HeadingAwarePDFTextStripper.java
@@ -1,0 +1,2393 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.text;
+
+import it.unimi.dsi.fastutil.doubles.Double2IntAVLTreeMap;
+import it.unimi.dsi.fastutil.doubles.Double2IntSortedMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.pdfbox.contentstream.operator.markedcontent.BeginMarkedContentSequence;
+import org.apache.pdfbox.contentstream.operator.markedcontent.BeginMarkedContentSequenceWithProperties;
+import org.apache.pdfbox.contentstream.operator.markedcontent.EndMarkedContentSequence;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageTree;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.documentinterchange.markedcontent.PDMarkedContent;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
+import org.apache.pdfbox.pdmodel.interactive.pagenavigation.PDThreadBead;
+import org.apache.pdfbox.util.IterativeMergeSort;
+
+import java.io.*;
+import java.text.Bidi;
+import java.text.Normalizer;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/* Vendored from PDFBox 3.0.5, with modifications to identify headings based on a font size heuristic.
+ */
+
+/**
+ * This class will take a pdf document and strip out all of the text and ignore the formatting and such. Please note; it
+ * is up to clients of this class to verify that a specific user has the correct permissions to extract text from the
+ * PDF document.
+ *
+ * The basic flow of this process is that we get a document and use a series of processXXX() functions that work on
+ * smaller and smaller chunks of the page. Eventually, we fully process each page and then print it.
+ *
+ * @author Ben Litchfield
+ */
+public class HeadingAwarePDFTextStripper extends LegacyPDFStreamEngine
+{
+    private static float defaultIndentThreshold = 2.0f;
+    private static float defaultDropThreshold = 2.5f;
+
+    private static final Log LOG = LogFactory.getLog(HeadingAwarePDFTextStripper.class);
+
+    // enable the ability to set the default indent/drop thresholds
+    // with -D system properties:
+    // pdftextstripper.indent
+    // pdftextstripper.drop
+    static
+    {
+        String strDrop = null, strIndent = null;
+        try
+        {
+            String className = HeadingAwarePDFTextStripper.class.getSimpleName().toLowerCase();
+            String prop = className + ".indent";
+            strIndent = System.getProperty(prop);
+            prop = className + ".drop";
+            strDrop = System.getProperty(prop);
+        }
+        catch (SecurityException e)
+        {
+            // PDFBOX-1946 when run in an applet
+            // ignore and use default
+            LOG.debug("Couldn't read system properties - using defaults", e);
+        }
+        if (strIndent != null && !strIndent.isEmpty())
+        {
+            try
+            {
+                defaultIndentThreshold = Float.parseFloat(strIndent);
+            }
+            catch (NumberFormatException nfe)
+            {
+                // ignore and use default
+            }
+        }
+        if (strDrop != null && !strDrop.isEmpty())
+        {
+            try
+            {
+                defaultDropThreshold = Float.parseFloat(strDrop);
+            }
+            catch (NumberFormatException nfe)
+            {
+                // ignore and use default
+            }
+        }
+    }
+
+    /**
+     * The platform's line separator.
+     */
+    protected static final String LINE_SEPARATOR = System.lineSeparator();
+
+    private String lineSeparator = LINE_SEPARATOR;
+    private String wordSeparator = " ";
+    private String paragraphStart = "";
+    private String paragraphEnd = "";
+    private String pageStart = "";
+    private String pageEnd = LINE_SEPARATOR;
+    private String headingStart = "";
+    private String headingEnd = "";
+    private String articleStart = "";
+    private String articleEnd = "";
+
+    private int currentPageNo = 1;
+    private int startPage = 1;
+    private int endPage = Integer.MAX_VALUE;
+    private PDOutlineItem startBookmark = null;
+
+    // 1-based bookmark pages
+    private int startBookmarkPageNumber = -1;
+    private int endBookmarkPageNumber = -1;
+
+    private PDOutlineItem endBookmark = null;
+    private boolean suppressDuplicateOverlappingText = true;
+    private boolean shouldSeparateByBeads = true;
+    private boolean sortByPosition = false;
+    private boolean addMoreFormatting = false;
+    private boolean ignoreContentStreamSpaceGlyphs = false;
+
+    private float indentThreshold = defaultIndentThreshold;
+    private float dropThreshold = defaultDropThreshold;
+
+    // we will need to estimate where to add spaces, these are used to help guess
+    private float spacingTolerance = .5f;
+    private float averageCharTolerance = .3f;
+
+    private List<PDRectangle> beadRectangles = null;
+
+    // use a stack so we don't get confused if another BDC within "/ActualText... BDC" block
+    private final Deque<PDMarkedContent> currentMarkedContents = new ArrayDeque<>();
+    // to replace the unicode of the first TextPosition and empty the others
+    private boolean firstActualTextPosition = false;
+    private String actualText = null;
+
+    /**
+     * The charactersByArticle is used to extract text by article divisions. For example a PDF that has two columns like
+     * a newspaper, we want to extract the first column and then the second column. In this example the PDF would have 2
+     * beads(or articles), one for each column. The size of the charactersByArticle would be 5, because not all text on
+     * the screen will fall into one of the articles. The five divisions are shown below
+     *
+     * Text before first article
+     * first article text
+     * text between first article and second article
+     * second article text
+     * text after second article
+     *
+     * Most PDFs won't have any beads, so charactersByArticle will contain a single entry.
+     */
+    protected ArrayList<List<TextPosition>> charactersByArticle = new ArrayList<>();
+
+    private final Map<String, TreeMap<Float, TreeSet<Float>>> characterListMapping = new HashMap<>();
+
+    protected PDDocument document;
+    protected Writer output;
+
+    /**
+     * True if we started a paragraph but haven't ended it yet.
+     */
+    private boolean inParagraph;
+
+    /**
+     * Instantiate a new PDFTextStripper object.
+     */
+    public HeadingAwarePDFTextStripper()
+    {
+        addOperator(new BeginMarkedContentSequenceWithProperties(this));
+        addOperator(new BeginMarkedContentSequence(this));
+        addOperator(new EndMarkedContentSequence(this));
+    }
+
+    /**
+     * This will return the text of a document. See writeText. <br>
+     * NOTE: The document must not be encrypted when coming into this method.
+     *
+     * <p>IMPORTANT: By default, text extraction is done in the same sequence as the text in the PDF page content stream.
+     * PDF is a graphic format, not a text format, and unlike HTML, it has no requirements that text one on page
+     * be rendered in a certain order. The order is the one that was determined by the software that created the
+     * PDF. To get text sorted from left to right and top to botton, use {@link #setSortByPosition(boolean)}.
+     *
+     * @param doc The document to get the text from.
+     * @return The text of the PDF document.
+     * @throws IOException if the doc state is invalid or it is encrypted.
+     */
+    public String getText(PDDocument doc) throws IOException
+    {
+        StringWriter outputStream = new StringWriter();
+        writeText(doc, outputStream);
+        return outputStream.toString();
+    }
+
+    private void resetEngine()
+    {
+        currentPageNo = 1;
+        document = null;
+        charactersByArticle.clear();
+        characterListMapping.clear();
+    }
+
+    /**
+     * This will take a PDDocument and write the text of that document to the print writer.
+     *
+     * @param doc The document to get the data from.
+     * @param outputStream The location to put the text.
+     *
+     * @throws IOException If the doc is in an invalid state.
+     */
+    public void writeText(PDDocument doc, Writer outputStream) throws IOException
+    {
+        resetEngine();
+        document = doc;
+        output = outputStream;
+        if (getAddMoreFormatting())
+        {
+            paragraphEnd = lineSeparator;
+            pageStart = lineSeparator;
+            articleStart = lineSeparator;
+            articleEnd = lineSeparator;
+        }
+        startDocument(document);
+        processPages(document.getPages());
+        endDocument(document);
+    }
+
+    /**
+     * This will process all of the pages and the text that is in them.
+     *
+     * @param pages The pages object in the document.
+     *
+     * @throws IOException If there is an error parsing the text.
+     */
+    protected void processPages(PDPageTree pages) throws IOException
+    {
+        PDPage startBookmarkPage = startBookmark == null ? null
+                : startBookmark.findDestinationPage(document);
+        if (startBookmarkPage != null)
+        {
+            startBookmarkPageNumber = pages.indexOf(startBookmarkPage) + 1;
+        }
+        else
+        {
+            // -1 = undefined
+            startBookmarkPageNumber = -1;
+        }
+
+        PDPage endBookmarkPage = endBookmark == null ? null
+                : endBookmark.findDestinationPage(document);
+        if (endBookmarkPage != null)
+        {
+            endBookmarkPageNumber = pages.indexOf(endBookmarkPage) + 1;
+        }
+        else
+        {
+            // -1 = undefined
+            endBookmarkPageNumber = -1;
+        }
+
+        if (startBookmarkPageNumber == -1 && startBookmark != null && endBookmarkPageNumber == -1
+                && endBookmark != null
+                && startBookmark.getCOSObject() == endBookmark.getCOSObject())
+        {
+            // this is a special case where both the start and end bookmark
+            // are the same but point to nothing. In this case
+            // we will not extract any text.
+            startBookmarkPageNumber = 0;
+            endBookmarkPageNumber = 0;
+        }
+
+        for (PDPage page : pages)
+        {
+            if (page.hasContents())
+            {
+                processPage(page);
+            }
+            currentPageNo++;
+        }
+    }
+
+    /**
+     * This method is available for subclasses of this class. It will be called before processing of the document start.
+     *
+     * @param document The PDF document that is being processed.
+     * @throws IOException If an IO error occurs.
+     */
+    protected void startDocument(PDDocument document) throws IOException
+    {
+        // no default implementation, but available for subclasses
+    }
+
+    /**
+     * This method is available for subclasses of this class. It will be called after processing of the document
+     * finishes.
+     *
+     * @param document The PDF document that is being processed.
+     * @throws IOException If an IO error occurs.
+     */
+    protected void endDocument(PDDocument document) throws IOException
+    {
+        // no default implementation, but available for subclasses
+    }
+
+    /**
+     * This will process the contents of a page.
+     *
+     * @param page The page to process.
+     *
+     * @throws IOException If there is an error processing the page.
+     */
+    @Override
+    public void processPage(PDPage page) throws IOException
+    {
+        if (currentPageNo >= startPage && currentPageNo <= endPage
+                && (startBookmarkPageNumber == -1 || currentPageNo >= startBookmarkPageNumber)
+                && (endBookmarkPageNumber == -1 || currentPageNo <= endBookmarkPageNumber))
+        {
+            startPage(page);
+
+            int numberOfArticleSections = 1;
+            if (shouldSeparateByBeads)
+            {
+                fillBeadRectangles(page);
+                numberOfArticleSections += beadRectangles.size() * 2;
+            }
+            int originalSize = charactersByArticle.size();
+            charactersByArticle.ensureCapacity(numberOfArticleSections);
+            int lastIndex = Math.max(numberOfArticleSections, originalSize);
+            for (int i = 0; i < lastIndex; i++)
+            {
+                if (i < originalSize)
+                {
+                    charactersByArticle.get(i).clear();
+                }
+                else
+                {
+                    if (numberOfArticleSections < originalSize)
+                    {
+                        //TODO Looks like decrement (--i) needed because next value will be ignored.
+                        // This segment is never reached in tests?!
+                        charactersByArticle.remove(i);
+                    }
+                    else
+                    {
+                        charactersByArticle.add(new ArrayList<>());
+                    }
+                }
+            }
+            characterListMapping.clear();
+            super.processPage(page);
+            writePage();
+            endPage(page);
+            page.removePageResourceFromCache();
+        }
+    }
+
+    private void fillBeadRectangles(PDPage page)
+    {
+        beadRectangles = new ArrayList<>();
+        for (PDThreadBead bead : page.getThreadBeads())
+        {
+            if (bead == null || bead.getRectangle() == null)
+            {
+                // can't skip, because of null entry handling in processTextPosition()
+                beadRectangles.add(null);
+                continue;
+            }
+
+            PDRectangle rect = bead.getRectangle();
+
+            // bead rectangle is in PDF coordinates (y=0 is bottom),
+            // glyphs are in image coordinates (y=0 is top),
+            // so we must flip
+            PDRectangle mediaBox = page.getMediaBox();
+            float upperRightY = mediaBox.getUpperRightY() - rect.getLowerLeftY();
+            float lowerLeftY = mediaBox.getUpperRightY() - rect.getUpperRightY();
+            rect.setLowerLeftY(lowerLeftY);
+            rect.setUpperRightY(upperRightY);
+
+            // adjust for cropbox
+            PDRectangle cropBox = page.getCropBox();
+            if (Float.compare(cropBox.getLowerLeftX(), 0) != 0 || Float.compare(cropBox.getLowerLeftY(), 0) != 0)
+            {
+                rect.setLowerLeftX(rect.getLowerLeftX() - cropBox.getLowerLeftX());
+                rect.setLowerLeftY(rect.getLowerLeftY() - cropBox.getLowerLeftY());
+                rect.setUpperRightX(rect.getUpperRightX() - cropBox.getLowerLeftX());
+                rect.setUpperRightY(rect.getUpperRightY() - cropBox.getLowerLeftY());
+            }
+
+            beadRectangles.add(rect);
+        }
+    }
+
+    /**
+     * Start a new article, which is typically defined as a column on a single page (also referred to as a bead). This
+     * assumes that the primary direction of text is left to right. Default implementation is to do nothing. Subclasses
+     * may provide additional information.
+     *
+     * @throws IOException If there is any error writing to the stream.
+     */
+    protected void startArticle() throws IOException
+    {
+        startArticle(true);
+    }
+
+    /**
+     * Start a new article, which is typically defined as a column on a single page (also referred to as a bead).
+     * Default implementation is to do nothing. Subclasses may provide additional information.
+     *
+     * @param isLTR true if primary direction of text is left to right.
+     * @throws IOException If there is any error writing to the stream.
+     */
+    protected void startArticle(boolean isLTR) throws IOException
+    {
+        output.write(getArticleStart());
+    }
+
+    /**
+     * End an article. Default implementation is to do nothing. Subclasses may provide additional information.
+     *
+     * @throws IOException If there is any error writing to the stream.
+     */
+    protected void endArticle() throws IOException
+    {
+        output.write(getArticleEnd());
+    }
+
+    /**
+     * Start a new page. Default implementation is to do nothing. Subclasses may provide additional information.
+     *
+     * @param page The page we are about to process.
+     *
+     * @throws IOException If there is any error writing to the stream.
+     */
+    protected void startPage(PDPage page) throws IOException
+    {
+        // default is to do nothing
+    }
+
+    /**
+     * End a page. Default implementation is to do nothing. Subclasses may provide additional information.
+     *
+     * @param page The page we are about to process.
+     *
+     * @throws IOException If there is any error writing to the stream.
+     */
+    protected void endPage(PDPage page) throws IOException
+    {
+        // default is to do nothing
+    }
+
+    private static final float END_OF_LAST_TEXT_X_RESET_VALUE = -1;
+    private static final float MAX_Y_FOR_LINE_RESET_VALUE = -Float.MAX_VALUE;
+    private static final float EXPECTED_START_OF_NEXT_WORD_X_RESET_VALUE = -Float.MAX_VALUE;
+    private static final float MAX_HEIGHT_FOR_LINE_RESET_VALUE = -1;
+    private static final float MIN_Y_TOP_FOR_LINE_RESET_VALUE = Float.MAX_VALUE;
+    private static final float LAST_WORD_SPACING_RESET_VALUE = -1;
+
+    /**
+     * This will print the text of the processed page to "output". It will estimate, based on the coordinates of the
+     * text, where newlines and word spacings should be placed. The text will be sorted only if that feature was
+     * enabled.
+     *
+     * @throws IOException If there is an error writing the text.
+     */
+    protected void writePage() throws IOException
+    {
+        float maxYForLine = MAX_Y_FOR_LINE_RESET_VALUE;
+        float minYTopForLine = MIN_Y_TOP_FOR_LINE_RESET_VALUE;
+        float endOfLastTextX = END_OF_LAST_TEXT_X_RESET_VALUE;
+        float lastWordSpacing = LAST_WORD_SPACING_RESET_VALUE;
+        float maxHeightForLine = MAX_HEIGHT_FOR_LINE_RESET_VALUE;
+        PositionWrapper lastPosition = null;
+        PositionWrapper lastLineStartPosition = null;
+
+        boolean startOfPage = true; // flag to indicate start of page
+        boolean startOfArticle;
+        if (!charactersByArticle.isEmpty())
+        {
+            writePageStart();
+        }
+
+        double headingBoundary = calculateHeadingFontSizeBoundary(charactersByArticle);
+
+        for (List<TextPosition> textList : charactersByArticle)
+        {
+            if (getSortByPosition())
+            {
+                TextPositionComparator comparator = new TextPositionComparator();
+
+                // because the TextPositionComparator is not transitive, but
+                // JDK7+ enforces transitivity on comparators, we need to use
+                // a custom mergesort implementation (which is slower, unfortunately).
+                try
+                {
+                    Collections.sort(textList, comparator);
+                }
+                catch (IllegalArgumentException e)
+                {
+                    IterativeMergeSort.sort(textList, comparator);
+                }
+                // PDFBOX-5487: Remove all space characters if contained within the adjacent letters
+                removeContainedSpaces(textList);
+            }
+
+            startArticle();
+            startOfArticle = true;
+
+            // Now cycle through to print the text.
+            // We queue up a line at a time before we print so that we can convert
+            // the line from presentation form to logical form (if needed).
+            List<LineItem> line = new ArrayList<>();
+
+            Iterator<TextPosition> textIter = textList.iterator();
+            // PDF files don't always store spaces. We will need to guess where we should add
+            // spaces based on the distances between TextPositions. Historically, this was done
+            // based on the size of the space character provided by the font. In general, this
+            // worked but there were cases where it did not work. Calculating the average character
+            // width and using that as a metric works better in some cases but fails in some cases
+            // where the spacing worked. So we use both. NOTE: Adobe reader also fails on some of
+            // these examples.
+
+            // Keeps track of the previous average character width
+            float previousAveCharWidth = -1;
+            while (textIter.hasNext())
+            {
+                TextPosition position = textIter.next();
+                PositionWrapper current = new PositionWrapper(position);
+                String characterValue = position.getUnicode();
+
+                // PDFBOX-3774: conditionally ignore spaces from the content stream
+                if (" ".equals(characterValue) && getIgnoreContentStreamSpaceGlyphs())
+                {
+                    continue;
+                }
+
+                // Resets the average character width when we see a change in font
+                // or a change in the font size
+                if (lastPosition != null
+                        && hasFontOrSizeChanged(position, lastPosition.getTextPosition()))
+                {
+                    previousAveCharWidth = -1;
+                }
+                float positionX;
+                float positionY;
+                float positionWidth;
+                float positionHeight;
+
+                // If we are sorting, then we need to use the text direction
+                // adjusted coordinates, because they were used in the sorting.
+                if (getSortByPosition())
+                {
+                    positionX = position.getXDirAdj();
+                    positionY = position.getYDirAdj();
+                    positionWidth = position.getWidthDirAdj();
+                    positionHeight = position.getHeightDir();
+                }
+                else
+                {
+                    positionX = position.getX();
+                    positionY = position.getY();
+                    positionWidth = position.getWidth();
+                    positionHeight = position.getHeight();
+                }
+
+                // The current amount of characters in a word
+                int wordCharCount = position.getIndividualWidths().length;
+
+                // Estimate the expected width of the space based on the
+                // space character with some margin.
+                float wordSpacing = position.getWidthOfSpace();
+                float deltaSpace;
+                if (Float.compare(wordSpacing, 0) == 0 || Float.isNaN(wordSpacing))
+                {
+                    deltaSpace = Float.MAX_VALUE;
+                }
+                else
+                {
+                    if (lastWordSpacing < 0)
+                    {
+                        deltaSpace = wordSpacing * getSpacingTolerance();
+                    }
+                    else
+                    {
+                        deltaSpace = (wordSpacing + lastWordSpacing) / 2f * getSpacingTolerance();
+                    }
+                }
+
+                // Estimate the expected width of the space based on the average character width
+                // with some margin. This calculation does not make a true average (average of
+                // averages) but we found that it gave the best results after numerous experiments.
+                // Based on experiments we also found that .3 worked well.
+                float averageCharWidth;
+                if (previousAveCharWidth < 0)
+                {
+                    averageCharWidth = positionWidth / wordCharCount;
+                }
+                else
+                {
+                    averageCharWidth = (previousAveCharWidth + positionWidth / wordCharCount) / 2f;
+                }
+                float deltaCharWidth = averageCharWidth * getAverageCharTolerance();
+
+                // Compares the values obtained by the average method and the wordSpacing method
+                // and picks the smaller number.
+                float expectedStartOfNextWordX = EXPECTED_START_OF_NEXT_WORD_X_RESET_VALUE;
+                if (Float.compare(endOfLastTextX, END_OF_LAST_TEXT_X_RESET_VALUE) != 0)
+                {
+                    expectedStartOfNextWordX = endOfLastTextX + Math.min(deltaSpace, deltaCharWidth);
+                }
+
+                if (lastPosition != null)
+                {
+                    if (startOfArticle)
+                    {
+                        lastPosition.setArticleStart();
+                        startOfArticle = false;
+                    }
+                    // RDD - Here we determine whether this text object is on the current
+                    // line. We use the lastBaselineFontSize to handle the superscript
+                    // case, and the size of the current font to handle the subscript case.
+                    // Text must overlap with the last rendered baseline text by at least
+                    // a small amount in order to be considered as being on the same line.
+
+                    // XXX BC: In theory, this check should really check if the next char is in
+                    // full range seen in this line. This is what I tried to do with minYTopForLine,
+                    // but this caused a lot of regression test failures. So, I'm leaving it be for
+                    // now
+                    if (!overlap(positionY, positionHeight, maxYForLine, maxHeightForLine))
+                    {
+                        writeLine(normalize(line), headingBoundary);
+                        line.clear();
+                        lastLineStartPosition = handleLineSeparation(current, lastPosition,
+                                lastLineStartPosition, maxHeightForLine);
+                        expectedStartOfNextWordX = EXPECTED_START_OF_NEXT_WORD_X_RESET_VALUE;
+                        maxYForLine = MAX_Y_FOR_LINE_RESET_VALUE;
+                        maxHeightForLine = MAX_HEIGHT_FOR_LINE_RESET_VALUE;
+                        minYTopForLine = MIN_Y_TOP_FOR_LINE_RESET_VALUE;
+                    }
+                    // test if our TextPosition starts after a new word would be expected to start
+                    if (Float.compare(expectedStartOfNextWordX, EXPECTED_START_OF_NEXT_WORD_X_RESET_VALUE) != 0
+                            && expectedStartOfNextWordX < positionX
+                            // only bother adding a word separator if the last character was not a word separator
+                            && (wordSeparator.isEmpty() || //
+                            (lastPosition.getTextPosition().getUnicode() != null
+                                    && !lastPosition.getTextPosition().getUnicode()
+                                    .endsWith(wordSeparator))))
+                    {
+                        line.add(LineItem.getWordSeparator());
+                    }
+                    // if there is at least the equivalent of one space
+                    // between the last character and the current one,
+                    // reset the max line height as the font size may have completely changed.
+                    if (Math.abs(position.getX()
+                            - lastPosition.getTextPosition().getX()) > (wordSpacing + deltaSpace))
+                    {
+                        maxYForLine = MAX_Y_FOR_LINE_RESET_VALUE;
+                        maxHeightForLine = MAX_HEIGHT_FOR_LINE_RESET_VALUE;
+                        minYTopForLine = MIN_Y_TOP_FOR_LINE_RESET_VALUE;
+                    }
+                }
+                if (positionY >= maxYForLine)
+                {
+                    maxYForLine = positionY;
+                }
+                // RDD - endX is what PDF considers to be the x coordinate of the
+                // end position of the text. We use it in computing our metrics below.
+                endOfLastTextX = positionX + positionWidth;
+
+                // add it to the list
+                if (characterValue != null)
+                {
+                    if (startOfPage && lastPosition == null)
+                    {
+                        writeParagraphStart();// not sure this is correct for RTL?
+                    }
+                    line.add(new LineItem(position));
+                }
+                maxHeightForLine = Math.max(maxHeightForLine, positionHeight);
+                minYTopForLine = Math.min(minYTopForLine, positionY - positionHeight);
+                lastPosition = current;
+                if (startOfPage)
+                {
+                    lastPosition.setParagraphStart();
+                    lastPosition.setLineStart();
+                    lastLineStartPosition = lastPosition;
+                    startOfPage = false;
+                }
+                lastWordSpacing = wordSpacing;
+                previousAveCharWidth = averageCharWidth;
+            }
+            // print the final line
+            if (!line.isEmpty())
+            {
+                writeLine(normalize(line), headingBoundary);
+                writeParagraphEnd();
+            }
+            endArticle();
+        }
+        writePageEnd();
+    }
+
+    private double calculateHeadingFontSizeBoundary(List<List<TextPosition>> charactersByArticle) {
+
+        DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
+        Double2IntSortedMap fontSizeMap = new Double2IntAVLTreeMap();
+        for (List<TextPosition> textList : charactersByArticle) {
+            for (var pos : textList) {
+                double size = pos.getFontSize();
+                fontSizeMap.mergeInt(size, 1, Integer::sum);
+                stats.accept(size);
+            }
+        }
+
+        int total = (int) stats.getCount();
+        int taken = 0;
+        double median = 0;
+        while (!fontSizeMap.isEmpty()) {
+            var entry = fontSizeMap.pollFirstEntry();
+            if (taken + entry.getValue() >= total / 2) {
+                median = entry.getKey();
+                break;
+            }
+            else {
+                taken += entry.getValue();
+                fontSizeMap.remove((double) entry.getKey());
+            }
+        }
+
+        if (median * 1.5 < stats.getMax()) {
+            return median * 1.5;
+        }
+        else {
+            if (stats.getMax() > 1.2 * median) {
+                return stats.getMax();
+            }
+            else {
+                return median * 1.5;
+            }
+        }
+    }
+
+    private boolean hasFontOrSizeChanged(TextPosition current, TextPosition last)
+    {
+        if (last == null)
+        {
+            return false;
+        }
+        // compare font sizes
+        if (Float.compare(current.getFontSize(), last.getFontSize()) != 0)
+        {
+            return true;
+        }
+        // compare font instances, may not work if the resource cache is disabled
+        if (current.getFont() == last.getFont())
+        {
+            return false;
+        }
+        String currentFontName = current.getFont().getName();
+        String lastFontName = last.getFont().getName();
+        if (currentFontName != null)
+        {
+            // compare font names
+            return !currentFontName.equals(lastFontName);
+        }
+        if (lastFontName != null)
+        {
+            // currentFontName is null but lastFontName isn't -> font changes
+            return true;
+        }
+        // both fonts don't have a name -> compare hashes
+        return current.getFont().hashCode() != last.getFont().hashCode();
+    }
+
+    private boolean overlap(float y1, float height1, float y2, float height2)
+    {
+        return within(y1, y2, .1f) || y2 <= y1 && y2 >= y1 - height1
+                || y1 <= y2 && y1 >= y2 - height2;
+    }
+
+    /**
+     * Remove all space characters if contained within the adjacent letters
+     */
+    private void removeContainedSpaces(List<TextPosition> textList)
+    {
+        Iterator<TextPosition> iterator = textList.iterator();
+
+        if (!iterator.hasNext())
+        {
+            return;
+        }
+        TextPosition previousPosition = iterator.next();
+
+        while (iterator.hasNext())
+        {
+            TextPosition position = iterator.next();
+            if (" ".equals(position.getUnicode()) && previousPosition.completelyContains(position))
+            {
+                iterator.remove();
+            }
+            else
+            {
+                previousPosition = position;
+            }
+        }
+    }
+
+    /**
+     * Write the line separator value to the output stream.
+     *
+     * @throws IOException If there is a problem writing out the line separator to the document.
+     */
+    protected void writeLineSeparator() throws IOException
+    {
+        output.write(getLineSeparator());
+    }
+
+    /**
+     * Write the word separator value to the output stream.
+     *
+     * @throws IOException If there is a problem writing out the word separator to the document.
+     */
+    protected void writeWordSeparator() throws IOException
+    {
+        output.write(getWordSeparator());
+    }
+
+    /**
+     * Write the string in TextPosition to the output stream.
+     *
+     * @param text The text to write to the stream.
+     * @throws IOException If there is an error when writing the text.
+     */
+    protected void writeCharacters(TextPosition text) throws IOException
+    {
+        output.write(text.getUnicode());
+    }
+
+    /**
+     * Write a Java string to the output stream. The default implementation will ignore the <code>textPositions</code>
+     * and just calls {@link #writeString(String)}.
+     *
+     * @param text The text to write to the stream.
+     * @param textPositions The TextPositions belonging to the text.
+     * @throws IOException If there is an error when writing the text.
+     */
+    protected void writeString(String text, List<TextPosition> textPositions) throws IOException
+    {
+        writeString(text);
+    }
+
+    /**
+     * Write a Java string to the output stream.
+     *
+     * @param text The text to write to the stream.
+     * @throws IOException If there is an error when writing the text.
+     */
+    protected void writeString(String text) throws IOException
+    {
+        output.write(text);
+    }
+
+    /**
+     * This will determine of two floating point numbers are within a specified variance.
+     *
+     * @param first The first number to compare to.
+     * @param second The second number to compare to.
+     * @param variance The allowed variance.
+     */
+    private boolean within(float first, float second, float variance)
+    {
+        return second < first + variance && second > first - variance;
+    }
+
+    @Override
+    public void beginMarkedContentSequence(COSName tag, COSDictionary properties)
+    {
+        PDMarkedContent markedContent = PDMarkedContent.create(tag, properties);
+        currentMarkedContents.push(markedContent);
+        actualText = markedContent.getActualText();
+        if (actualText != null)
+        {
+            actualText = actualText.replace("\u00ad", ""); // remove soft hyphens
+            firstActualTextPosition = true;
+        }
+        super.beginMarkedContentSequence(tag, properties);
+    }
+
+    @Override
+    public void endMarkedContentSequence()
+    {
+        PDMarkedContent markedContent = currentMarkedContents.peek();
+        if (markedContent != null)
+        {
+            if (markedContent.getActualText() != null)
+            {
+                actualText = null;
+            }
+            currentMarkedContents.pop();
+        }
+        super.endMarkedContentSequence();
+    }
+
+    /**
+     * This will process a TextPosition object and add the text to the list of characters on a page. It takes care of
+     * overlapping text.
+     *
+     * @param text The text to process.
+     */
+    @Override
+    protected void processTextPosition(TextPosition text)
+    {
+        if (actualText != null)
+        {
+            if (firstActualTextPosition)
+            {
+                text.setUnicode(actualText);
+                firstActualTextPosition = false;
+            }
+            else
+            {
+                text.setUnicode("");
+            }
+        }
+        boolean showCharacter = true;
+        if (suppressDuplicateOverlappingText && actualText == null)
+        {
+            showCharacter = false;
+            String textCharacter = text.getUnicode();
+            float textX = text.getX();
+            float textY = text.getY();
+            TreeMap<Float, TreeSet<Float>> sameTextCharacters = characterListMapping
+                    .computeIfAbsent(textCharacter, k -> new TreeMap<>());
+            // RDD - Here we compute the value that represents the end of the rendered
+            // text. This value is used to determine whether subsequent text rendered
+            // on the same line overwrites the current text.
+            //
+            // We subtract any positive padding to handle cases where extreme amounts
+            // of padding are applied, then backed off (not sure why this is done, but there
+            // are cases where the padding is on the order of 10x the character width, and
+            // the TJ just backs up to compensate after each character). Also, we subtract
+            // an amount to allow for kerning (a percentage of the width of the last
+            // character).
+            boolean suppressCharacter = false;
+            float tolerance = text.getWidth() / textCharacter.length() / 3.0f;
+
+            SortedMap<Float, TreeSet<Float>> xMatches = sameTextCharacters.subMap(textX - tolerance,
+                    textX + tolerance);
+            for (TreeSet<Float> xMatch : xMatches.values())
+            {
+                SortedSet<Float> yMatches = xMatch.subSet(textY - tolerance, textY + tolerance);
+                if (!yMatches.isEmpty())
+                {
+                    suppressCharacter = true;
+                    break;
+                }
+            }
+            if (!suppressCharacter)
+            {
+                TreeSet<Float> ySet = sameTextCharacters.computeIfAbsent(textX, k -> new TreeSet<>());
+                ySet.add(textY);
+                showCharacter = true;
+            }
+        }
+        if (showCharacter)
+        {
+            // if we are showing the character then we need to determine which article it belongs to
+            int foundArticleDivisionIndex = -1;
+            int notFoundButFirstLeftAndAboveArticleDivisionIndex = -1;
+            int notFoundButFirstLeftArticleDivisionIndex = -1;
+            int notFoundButFirstAboveArticleDivisionIndex = -1;
+            float x = text.getX();
+            float y = text.getY();
+            if (shouldSeparateByBeads)
+            {
+                for (int i = 0; i < beadRectangles.size() && foundArticleDivisionIndex == -1; i++)
+                {
+                    PDRectangle rect = beadRectangles.get(i);
+                    if (rect != null)
+                    {
+                        if (rect.contains(x, y))
+                        {
+                            foundArticleDivisionIndex = i * 2 + 1;
+                        }
+                        else if ((x < rect.getLowerLeftX() || y < rect.getUpperRightY())
+                                && notFoundButFirstLeftAndAboveArticleDivisionIndex == -1)
+                        {
+                            notFoundButFirstLeftAndAboveArticleDivisionIndex = i * 2;
+                        }
+                        else if (x < rect.getLowerLeftX()
+                                && notFoundButFirstLeftArticleDivisionIndex == -1)
+                        {
+                            notFoundButFirstLeftArticleDivisionIndex = i * 2;
+                        }
+                        else if (y < rect.getUpperRightY()
+                                && notFoundButFirstAboveArticleDivisionIndex == -1)
+                        {
+                            notFoundButFirstAboveArticleDivisionIndex = i * 2;
+                        }
+                    }
+                    else
+                    {
+                        foundArticleDivisionIndex = 0;
+                    }
+                }
+            }
+            else
+            {
+                foundArticleDivisionIndex = 0;
+            }
+            int articleDivisionIndex;
+            if (foundArticleDivisionIndex != -1)
+            {
+                articleDivisionIndex = foundArticleDivisionIndex;
+            }
+            else if (notFoundButFirstLeftAndAboveArticleDivisionIndex != -1)
+            {
+                articleDivisionIndex = notFoundButFirstLeftAndAboveArticleDivisionIndex;
+            }
+            else if (notFoundButFirstLeftArticleDivisionIndex != -1)
+            {
+                articleDivisionIndex = notFoundButFirstLeftArticleDivisionIndex;
+            }
+            else if (notFoundButFirstAboveArticleDivisionIndex != -1)
+            {
+                articleDivisionIndex = notFoundButFirstAboveArticleDivisionIndex;
+            }
+            else
+            {
+                articleDivisionIndex = charactersByArticle.size() - 1;
+            }
+
+            List<TextPosition> textList = charactersByArticle.get(articleDivisionIndex);
+
+            // In the wild, some PDF encoded documents put diacritics (accents on
+            // top of characters) into a separate Tj element. When displaying them
+            // graphically, the two chunks get overlaid. With text output though,
+            // we need to do the overlay. This code recombines the diacritic with
+            // its associated character if the two are consecutive.
+            if (textList.isEmpty())
+            {
+                textList.add(text);
+            }
+            else
+            {
+                // test if we overlap the previous entry.
+                // Note that we are making an assumption that we need to only look back
+                // one TextPosition to find what we are overlapping.
+                // This may not always be true. */
+                TextPosition previousTextPosition = textList.get(textList.size() - 1);
+                if (text.isDiacritic() && previousTextPosition.contains(text))
+                {
+                    previousTextPosition.mergeDiacritic(text);
+                }
+                // If the previous TextPosition was the diacritic, merge it into this
+                // one and remove it from the list.
+                else if (previousTextPosition.isDiacritic() && text.contains(previousTextPosition))
+                {
+                    text.mergeDiacritic(previousTextPosition);
+                    textList.remove(textList.size() - 1);
+                    textList.add(text);
+                }
+                else
+                {
+                    textList.add(text);
+                }
+            }
+        }
+    }
+
+    /**
+     * This is the page that the text extraction will start on. The pages start at page 1. For example in a 5 page PDF
+     * document, if the start page is 1 then all pages will be extracted. If the start page is 4 then pages 4 and 5 will
+     * be extracted. The default value is 1.
+     *
+     * @return Value of property startPage.
+     */
+    public int getStartPage()
+    {
+        return startPage;
+    }
+
+    /**
+     * This will set the first page to be extracted by this class.
+     *
+     * @param startPageValue New value of 1-based startPage property.
+     */
+    public void setStartPage(int startPageValue)
+    {
+        if (startPageValue <= 0)
+        {
+            LOG.warn("Parameter must be 1-based, but is " + startPageValue);
+        }
+        startPage = startPageValue;
+    }
+
+    /**
+     * This will get the last page that will be extracted. This is inclusive, for example if a 5 page PDF an endPage
+     * value of 5 would extract the entire document, an end page of 2 would extract pages 1 and 2. This defaults to
+     * Integer.MAX_VALUE such that all pages of the pdf will be extracted.
+     *
+     * @return Value of property endPage.
+     */
+    public int getEndPage()
+    {
+        return endPage;
+    }
+
+    /**
+     * This will set the last page to be extracted by this class.
+     *
+     * @param endPageValue New value of 1-based endPage property.
+     */
+    public void setEndPage(int endPageValue)
+    {
+        if (endPageValue <= 0)
+        {
+            LOG.warn("Parameter must be 1-based, but is " + endPageValue);
+        }
+        endPage = endPageValue;
+    }
+
+    /**
+     * Set the desired line separator for output text. The line.separator system property is used if the line separator
+     * preference is not set explicitly using this method.
+     *
+     * @param separator The desired line separator string.
+     */
+    public void setLineSeparator(String separator)
+    {
+        lineSeparator = separator;
+    }
+
+    /**
+     * This will get the line separator.
+     *
+     * @return The desired line separator string.
+     */
+    public String getLineSeparator()
+    {
+        return lineSeparator;
+    }
+
+    /**
+     * This will get the word separator.
+     *
+     * @return The desired word separator string.
+     */
+    public String getWordSeparator()
+    {
+        return wordSeparator;
+    }
+
+    /**
+     * Set the desired word separator for output text. The PDFBox text extraction algorithm will output a space
+     * character if there is enough space between two words. By default a space character is used. If you need and
+     * accurate count of characters that are found in a PDF document then you might want to set the word separator to
+     * the empty string.
+     *
+     * @param separator The desired page separator string.
+     */
+    public void setWordSeparator(String separator)
+    {
+        wordSeparator = separator;
+    }
+
+    /**
+     * @return Returns the suppressDuplicateOverlappingText.
+     */
+    public boolean getSuppressDuplicateOverlappingText()
+    {
+        return suppressDuplicateOverlappingText;
+    }
+
+    /**
+     * Get the current page number that is being processed.
+     *
+     * @return A 1 based number representing the current page.
+     */
+    protected int getCurrentPageNo()
+    {
+        return currentPageNo;
+    }
+
+    /**
+     * The output stream that is being written to.
+     *
+     * @return The stream that output is being written to.
+     */
+    protected Writer getOutput()
+    {
+        return output;
+    }
+
+    /**
+     * Character strings are grouped by articles. It is quite common that there will only be a single article. This
+     * returns a List that contains List objects, the inner lists will contain TextPosition objects.
+     *
+     * @return A double List of TextPositions for all text strings on the page.
+     */
+    protected List<List<TextPosition>> getCharactersByArticle()
+    {
+        return charactersByArticle;
+    }
+
+    /**
+     * By default the text stripper will attempt to remove text that overlapps each other. Word paints the same
+     * character several times in order to make it look bold. By setting this to false all text will be extracted, which
+     * means that certain sections will be duplicated, but better performance will be noticed.
+     *
+     * @param suppressDuplicateOverlappingTextValue The suppressDuplicateOverlappingText to set.
+     */
+    public void setSuppressDuplicateOverlappingText(boolean suppressDuplicateOverlappingTextValue)
+    {
+        suppressDuplicateOverlappingText = suppressDuplicateOverlappingTextValue;
+    }
+
+    /**
+     * This will tell if the text stripper should separate by beads.
+     *
+     * @return If the text will be grouped by beads.
+     */
+    public boolean getSeparateByBeads()
+    {
+        return shouldSeparateByBeads;
+    }
+
+    /**
+     * Set if the text stripper should group the text output by a list of beads. The default value is true!
+     *
+     * @param aShouldSeparateByBeads The new grouping of beads.
+     */
+    public void setShouldSeparateByBeads(boolean aShouldSeparateByBeads)
+    {
+        shouldSeparateByBeads = aShouldSeparateByBeads;
+    }
+
+    /**
+     * Get the bookmark where text extraction should end, inclusive. Default is null.
+     *
+     * @return The ending bookmark.
+     */
+    public PDOutlineItem getEndBookmark()
+    {
+        return endBookmark;
+    }
+
+    /**
+     * Set the bookmark where the text extraction should stop.
+     *
+     * @param aEndBookmark The ending bookmark.
+     */
+    public void setEndBookmark(PDOutlineItem aEndBookmark)
+    {
+        endBookmark = aEndBookmark;
+    }
+
+    /**
+     * Get the bookmark where text extraction should start, inclusive. Default is null.
+     *
+     * @return The starting bookmark.
+     */
+    public PDOutlineItem getStartBookmark()
+    {
+        return startBookmark;
+    }
+
+    /**
+     * Set the bookmark where text extraction should start, inclusive.
+     *
+     * @param aStartBookmark The starting bookmark.
+     */
+    public void setStartBookmark(PDOutlineItem aStartBookmark)
+    {
+        startBookmark = aStartBookmark;
+    }
+
+    /**
+     * This will tell if the text stripper should add some more text formatting.
+     *
+     * @return true if some more text formatting will be added
+     */
+    public boolean getAddMoreFormatting()
+    {
+        return addMoreFormatting;
+    }
+
+    /**
+     * There will some additional text formatting be added if addMoreFormatting is set to true. Default is false.
+     *
+     * @param newAddMoreFormatting Tell PDFBox to add some more text formatting
+     */
+    public void setAddMoreFormatting(boolean newAddMoreFormatting)
+    {
+        addMoreFormatting = newAddMoreFormatting;
+    }
+
+    /**
+     * This will tell if the text stripper should sort the text tokens before writing to the stream.
+     *
+     * @return true If the text tokens will be sorted before being written.
+     */
+    public boolean getSortByPosition()
+    {
+        return sortByPosition;
+    }
+
+    /**
+     * The order of the text tokens in a PDF file may not be in the same as they appear visually on the screen. For
+     * example, a PDF writer may write out all text by font, so all bold or larger text, then make a second pass and
+     * write out the normal text.<br>
+     * The default is to <b>not</b> sort by position.<br>
+     * <br>
+     * A PDF writer could choose to write each character in a different order. By default PDFBox does <b>not</b> sort
+     * the text tokens before processing them due to performance reasons.
+     *
+     * @param newSortByPosition Tell PDFBox to sort the text positions.
+     */
+    public void setSortByPosition(boolean newSortByPosition)
+    {
+        sortByPosition = newSortByPosition;
+    }
+
+    /**
+     * Determines whether spaces in the content stream text rendering instructions will be ignored
+     * during text extraction.
+     *
+     * @return true is space glyphs in the content stream text rendering instructions will be
+     * ignored - default is false
+     */
+    public boolean getIgnoreContentStreamSpaceGlyphs()
+    {
+        return ignoreContentStreamSpaceGlyphs;
+    }
+
+    /**
+     * Instruct the algorithm to ignore any spaces in the text rendering instructions in the content
+     * stream, and instead rely purely on the algorithm to determine where word breaks are.
+     *
+     * This can improve text extraction results where the content stream is sorted by position and
+     * has text overlapping spaces, but could cause some word breaks to not be added to the output
+     *
+     * @param newIgnoreContentStreamSpaceGlyphs whether PDF Box should ignore context stream spaces
+     */
+    public void setIgnoreContentStreamSpaceGlyphs(boolean newIgnoreContentStreamSpaceGlyphs)
+    {
+        ignoreContentStreamSpaceGlyphs = newIgnoreContentStreamSpaceGlyphs;
+    }
+
+    /**
+     * Get the current space width-based tolerance value that is being used to estimate where spaces in text should be
+     * added. Note that the default value for this has been determined from trial and error.
+     *
+     * @return The current tolerance / scaling factor
+     */
+    public float getSpacingTolerance()
+    {
+        return spacingTolerance;
+    }
+
+    /**
+     * Set the space width-based tolerance value that is used to estimate where spaces in text should be added. Note
+     * that the default value for this has been determined from trial and error. Setting this value larger will reduce
+     * the number of spaces added.
+     *
+     * @param spacingToleranceValue tolerance / scaling factor to use
+     */
+    public void setSpacingTolerance(float spacingToleranceValue)
+    {
+        spacingTolerance = spacingToleranceValue;
+    }
+
+    /**
+     * Get the current character width-based tolerance value that is being used to estimate where spaces in text should
+     * be added. Note that the default value for this has been determined from trial and error.
+     *
+     * @return The current tolerance / scaling factor
+     */
+    public float getAverageCharTolerance()
+    {
+        return averageCharTolerance;
+    }
+
+    /**
+     * Set the character width-based tolerance value that is used to estimate where spaces in text should be added. Note
+     * that the default value for this has been determined from trial and error. Setting this value larger will reduce
+     * the number of spaces added.
+     *
+     * @param averageCharToleranceValue average tolerance / scaling factor to use
+     */
+    public void setAverageCharTolerance(float averageCharToleranceValue)
+    {
+        averageCharTolerance = averageCharToleranceValue;
+    }
+
+    /**
+     * returns the multiple of whitespace character widths for the current text which the current line start can be
+     * indented from the previous line start beyond which the current line start is considered to be a paragraph start.
+     *
+     * @return the number of whitespace character widths to use when detecting paragraph indents.
+     */
+    public float getIndentThreshold()
+    {
+        return indentThreshold;
+    }
+
+    /**
+     * sets the multiple of whitespace character widths for the current text which the current line start can be
+     * indented from the previous line start beyond which the current line start is considered to be a paragraph start.
+     * The default value is 2.0.
+     *
+     * @param indentThresholdValue the number of whitespace character widths to use when detecting paragraph indents.
+     */
+    public void setIndentThreshold(float indentThresholdValue)
+    {
+        indentThreshold = indentThresholdValue;
+    }
+
+    /**
+     * the minimum whitespace, as a multiple of the max height of the current characters beyond which the current line
+     * start is considered to be a paragraph start.
+     *
+     * @return the character height multiple for max allowed whitespace between lines in the same paragraph.
+     */
+    public float getDropThreshold()
+    {
+        return dropThreshold;
+    }
+
+    /**
+     * sets the minimum whitespace, as a multiple of the max height of the current characters beyond which the current
+     * line start is considered to be a paragraph start. The default value is 2.5.
+     *
+     * @param dropThresholdValue the character height multiple for max allowed whitespace between lines in the same
+     * paragraph.
+     */
+    public void setDropThreshold(float dropThresholdValue)
+    {
+        dropThreshold = dropThresholdValue;
+    }
+
+    /**
+     * Returns the string which will be used at the beginning of a paragraph.
+     *
+     * @return the paragraph start string
+     */
+    public String getParagraphStart()
+    {
+        return paragraphStart;
+    }
+
+    /**
+     * Sets the string which will be used at the beginning of a paragraph.
+     *
+     * @param s the paragraph start string
+     */
+    public void setParagraphStart(String s)
+    {
+        paragraphStart = s;
+    }
+
+    /**
+     * Returns the string which will be used at the end of a paragraph.
+     *
+     * @return the paragraph end string
+     */
+    public String getParagraphEnd()
+    {
+        return paragraphEnd;
+    }
+
+    /**
+     * Sets the string which will be used at the end of a paragraph.
+     *
+     * @param s the paragraph end string
+     */
+    public void setParagraphEnd(String s)
+    {
+        paragraphEnd = s;
+    }
+
+    /**
+     * Returns the string which will be used at the beginning of a page.
+     *
+     * @return the page start string
+     */
+    public String getPageStart()
+    {
+        return pageStart;
+    }
+
+    /**
+     * Sets the string which will be used at the beginning of a page.
+     *
+     * @param pageStartValue the page start string
+     */
+    public void setPageStart(String pageStartValue)
+    {
+        pageStart = pageStartValue;
+    }
+
+    /**
+     * Returns the string which will be used at the end of a page.
+     *
+     * @return the page end string
+     */
+    public String getPageEnd()
+    {
+        return pageEnd;
+    }
+
+    /**
+     * Sets the string which will be used at the end of a page.
+     *
+     * @param pageEndValue the page end string
+     */
+    public void setPageEnd(String pageEndValue)
+    {
+        pageEnd = pageEndValue;
+    }
+
+    /**
+     * Returns the string which will be used at the beginning of an article.
+     *
+     * @return the article start string
+     */
+    public String getArticleStart()
+    {
+        return articleStart;
+    }
+
+    /**
+     * Sets the string which will be used at the beginning of an article.
+     *
+     * @param articleStartValue the article start string
+     */
+    public void setArticleStart(String articleStartValue)
+    {
+        articleStart = articleStartValue;
+    }
+
+    /**
+     * Returns the string which will be used at the end of an article.
+     *
+     * @return the article end string
+     */
+    public String getArticleEnd()
+    {
+        return articleEnd;
+    }
+
+    /**
+     * Sets the string which will be used at the end of an article.
+     *
+     * @param articleEndValue the article end string
+     */
+    public void setArticleEnd(String articleEndValue)
+    {
+        articleEnd = articleEndValue;
+    }
+
+    public void setHeadingStart(String headingStartValue)
+    {
+        headingStart = headingStartValue;
+    }
+
+    public String getHeadingStart()
+    {
+        return headingStart;
+    }
+
+    public void setHeadingEnd(String headingEndValue)
+    {
+        headingEnd = headingEndValue;
+    }
+
+    public String getHeadingEnd()
+    {
+        return headingEnd;
+    }
+
+    /**
+     * handles the line separator for a new line given the specified current and previous TextPositions.
+     *
+     * @param current the current text position
+     * @param lastPosition the previous text position
+     * @param lastLineStartPosition the last text position that followed a line separator.
+     * @param maxHeightForLine max height for positions since lastLineStartPosition
+     * @return start position of the last line
+     * @throws IOException if something went wrong
+     */
+    private PositionWrapper handleLineSeparation(PositionWrapper current,
+                                                 PositionWrapper lastPosition, PositionWrapper lastLineStartPosition,
+                                                 float maxHeightForLine) throws IOException
+    {
+        current.setLineStart();
+        isParagraphSeparation(current, lastPosition, lastLineStartPosition, maxHeightForLine);
+        lastLineStartPosition = current;
+        if (current.isParagraphStart())
+        {
+            if (lastPosition.isArticleStart())
+            {
+                if (lastPosition.isLineStart())
+                {
+                    writeLineSeparator();
+                }
+                writeParagraphStart();
+            }
+            else
+            {
+                writeLineSeparator();
+                writeParagraphSeparator();
+            }
+        }
+        else
+        {
+            writeLineSeparator();
+        }
+        return lastLineStartPosition;
+    }
+
+    /**
+     * tests the relationship between the last text position, the current text position and the last text position that
+     * followed a line separator to decide if the gap represents a paragraph separation. This should <i>only</i> be
+     * called for consecutive text positions that first pass the line separation test.
+     * <p>
+     * This base implementation tests to see if the lastLineStartPosition is null OR if the current vertical position
+     * has dropped below the last text vertical position by at least 2.5 times the current text height OR if the current
+     * horizontal position is indented by at least 2 times the current width of a space character.
+     * </p>
+     * <p>
+     * This also attempts to identify text that is indented under a hanging indent.
+     * </p>
+     * <p>
+     * This method sets the isParagraphStart and isHangingIndent flags on the current position object.
+     * </p>
+     *
+     * @param position the current text position. This may have its isParagraphStart or isHangingIndent flags set upon
+     * return.
+     * @param lastPosition the previous text position (should not be null).
+     * @param lastLineStartPosition the last text position that followed a line separator, or null.
+     * @param maxHeightForLine max height for text positions since lasLineStartPosition.
+     */
+    private void isParagraphSeparation(PositionWrapper position, PositionWrapper lastPosition,
+                                       PositionWrapper lastLineStartPosition, float maxHeightForLine)
+    {
+        boolean result = false;
+        if (lastLineStartPosition == null)
+        {
+            result = true;
+        }
+        else
+        {
+            float yGap = Math.abs(position.getTextPosition().getYDirAdj()
+                    - lastPosition.getTextPosition().getYDirAdj());
+            float newYVal = multiplyFloat(getDropThreshold(), maxHeightForLine);
+            // do we need to flip this for rtl?
+            float xGap = position.getTextPosition().getXDirAdj()
+                    - lastLineStartPosition.getTextPosition().getXDirAdj();
+            float newXVal = multiplyFloat(getIndentThreshold(),
+                    position.getTextPosition().getWidthOfSpace());
+            float positionWidth = multiplyFloat(0.25f, position.getTextPosition().getWidth());
+
+            if (yGap > newYVal)
+            {
+                result = true;
+            }
+            else if (xGap > newXVal)
+            {
+                // text is indented, but try to screen for hanging indent
+                if (!lastLineStartPosition.isParagraphStart())
+                {
+                    result = true;
+                }
+                else
+                {
+                    position.setHangingIndent();
+                }
+            }
+            else if (xGap < -position.getTextPosition().getWidthOfSpace())
+            {
+                // text is left of previous line. Was it a hanging indent?
+                if (!lastLineStartPosition.isParagraphStart())
+                {
+                    result = true;
+                }
+            }
+            else if (Math.abs(xGap) < positionWidth)
+            {
+                // current horizontal position is within 1/4 a char of the last
+                // linestart. We'll treat them as lined up.
+                if (lastLineStartPosition.isHangingIndent())
+                {
+                    position.setHangingIndent();
+                }
+                else if (lastLineStartPosition.isParagraphStart())
+                {
+                    // check to see if the previous line looks like
+                    // any of a number of standard list item formats
+                    Pattern liPattern = matchListItemPattern(lastLineStartPosition);
+                    if (liPattern != null)
+                    {
+                        Pattern currentPattern = matchListItemPattern(position);
+                        if (liPattern == currentPattern)
+                        {
+                            result = true;
+                        }
+                    }
+                }
+            }
+        }
+        if (result)
+        {
+            position.setParagraphStart();
+        }
+    }
+
+    private float multiplyFloat(float value1, float value2)
+    {
+        // multiply 2 floats and truncate the resulting value to 3 decimal places
+        // to avoid wrong results when comparing with another float
+        return Math.round(value1 * value2 * 1000) / 1000f;
+    }
+
+    /**
+     * writes the paragraph separator string to the output.
+     *
+     * @throws IOException if something went wrong
+     */
+    protected void writeParagraphSeparator() throws IOException
+    {
+        writeParagraphEnd();
+        writeParagraphStart();
+    }
+
+    /**
+     * Write something (if defined) at the start of a paragraph.
+     *
+     * @throws IOException if something went wrong
+     */
+    protected void writeParagraphStart() throws IOException
+    {
+        if (inParagraph)
+        {
+            writeParagraphEnd();
+            inParagraph = false;
+        }
+        output.write(getParagraphStart());
+        inParagraph = true;
+    }
+
+    /**
+     * Write something (if defined) at the end of a paragraph.
+     *
+     * @throws IOException if something went wrong
+     */
+    protected void writeParagraphEnd() throws IOException
+    {
+        if (!inParagraph)
+        {
+            writeParagraphStart();
+        }
+        output.write(getParagraphEnd());
+        inParagraph = false;
+    }
+
+    /**
+     * Write something (if defined) at the start of a page.
+     *
+     * @throws IOException if something went wrong
+     */
+    protected void writePageStart() throws IOException
+    {
+        output.write(getPageStart());
+    }
+
+    /**
+     * Write something (if defined) at the end of a page.
+     *
+     * @throws IOException if something went wrong
+     */
+    protected void writePageEnd() throws IOException
+    {
+        output.write(getPageEnd());
+    }
+
+
+    protected void writeHeadingStart() throws IOException
+    {
+        output.write(getHeadingStart());
+    }
+
+    protected void writeHeadingEnd() throws IOException
+    {
+        output.write(getHeadingEnd());
+    }
+    /**
+     * returns the list item Pattern object that matches the text at the specified PositionWrapper or null if the text
+     * does not match such a pattern. The list of Patterns tested against is given by the {@link #getListItemPatterns()}
+     * method. To add to the list, simply override that method (if sub-classing) or explicitly supply your own list
+     * using {@link #setListItemPatterns(List)}.
+     *
+     * @param pw position
+     * @return the matching pattern
+     */
+    private Pattern matchListItemPattern(PositionWrapper pw)
+    {
+        TextPosition tp = pw.getTextPosition();
+        String txt = tp.getUnicode();
+        return matchPattern(txt, getListItemPatterns());
+    }
+
+    /**
+     * a list of regular expressions that match commonly used list item formats, i.e. bullets, numbers, letters, Roman
+     * numerals, etc. Not meant to be comprehensive.
+     */
+    private static final String[] LIST_ITEM_EXPRESSIONS = { "\\.", "\\d+\\.", "\\[\\d+\\]",
+            "\\d+\\)", "[A-Z]\\.", "[a-z]\\.", "[A-Z]\\)", "[a-z]\\)", "[IVXL]+\\.",
+            "[ivxl]+\\.", };
+
+    private List<Pattern> listOfPatterns = null;
+
+    /**
+     * use to supply a different set of regular expression patterns for matching list item starts.
+     *
+     * @param patterns list of patterns
+     */
+    protected void setListItemPatterns(List<Pattern> patterns)
+    {
+        listOfPatterns = patterns;
+    }
+
+    /**
+     * returns a list of regular expression Patterns representing different common list item formats. For example
+     * numbered items of form:
+     * <ol>
+     * <li>some text</li>
+     * <li>more text</li>
+     * </ol>
+     * or
+     * <ul>
+     * <li>some text</li>
+     * <li>more text</li>
+     * </ul>
+     * etc., all begin with some character pattern. The pattern "\\d+\." (matches "1.", "2.", ...) or "\[\\d+\]"
+     * (matches "[1]", "[2]", ...).
+     * <p>
+     * This method returns a list of such regular expression Patterns.
+     *
+     * @return a list of Pattern objects.
+     */
+    protected List<Pattern> getListItemPatterns()
+    {
+        if (listOfPatterns == null)
+        {
+            listOfPatterns = new ArrayList<>();
+            for (String expression : LIST_ITEM_EXPRESSIONS)
+            {
+                Pattern p = Pattern.compile(expression);
+                listOfPatterns.add(p);
+            }
+        }
+        return listOfPatterns;
+    }
+
+    /**
+     * iterates over the specified list of Patterns until it finds one that matches the specified string. Then returns
+     * the Pattern.
+     * <p>
+     * Order of the supplied list of patterns is important as most common patterns should come first. Patterns should be
+     * strict in general, and all will be used with case sensitivity on.
+     * </p>
+     *
+     * @param string the string to be searched
+     * @param patterns list of patterns
+     * @return matching pattern
+     */
+    protected static Pattern matchPattern(String string, List<Pattern> patterns)
+    {
+        for (Pattern p : patterns)
+        {
+            if (p.matcher(string).matches())
+            {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    private double getAverageFontSizeOfLine(List<WordWithTextPositions> line)
+    {
+        double sum = 0;
+        int count = 0;
+
+        for (var word : line)
+        {
+            for (var textPosition : word.getTextPositions())
+            {
+                sum += textPosition.getFontSize();
+                count++;
+            }
+        }
+
+        if (count == 0)
+        {
+            return 0;
+        }
+        return sum / count;
+    }
+
+    /**
+     * Write a list of string containing a whole line of a document.
+     *
+     * @param line a list with the words of the given line
+     * @throws IOException if something went wrong
+     */
+    private void writeLine(List<WordWithTextPositions> line, double headingBoundary)
+            throws IOException
+    {
+        if (line.isEmpty())
+            return;
+
+        double avgFontSize = getAverageFontSizeOfLine(line);
+        boolean isHeading = avgFontSize >= headingBoundary && (line.size() > 1 || line.getFirst().text.length() > 2);
+
+        if (isHeading) {
+            writeHeadingStart();
+        }
+
+        int numberOfStrings = line.size();
+        for (int i = 0; i < numberOfStrings; i++)
+        {
+            WordWithTextPositions word = line.get(i);
+            writeString(word.getText(), word.getTextPositions());
+            if (i < numberOfStrings - 1)
+            {
+                writeWordSeparator();
+            }
+        }
+
+        if (isHeading) {
+            writeHeadingEnd();
+        }
+    }
+
+    /**
+     * Normalize the given list of TextPositions.
+     *
+     * @param line list of TextPositions
+     * @return a list of strings, one string for every word
+     */
+    private List<WordWithTextPositions> normalize(List<LineItem> line)
+    {
+        List<WordWithTextPositions> normalized = new LinkedList<>();
+        StringBuilder lineBuilder = new StringBuilder();
+        List<TextPosition> wordPositions = new ArrayList<>();
+
+        for (LineItem item : line)
+        {
+            lineBuilder = normalizeAdd(normalized, lineBuilder, wordPositions, item);
+        }
+
+        if (lineBuilder.length() > 0)
+        {
+            normalized.add(createWord(lineBuilder.toString(), wordPositions));
+        }
+        return normalized;
+    }
+
+    /**
+     * Handles the LTR and RTL direction of the given words. The whole implementation stands and falls with the given
+     * word. If the word is a full line, the results will be the best. If the word contains of single words or
+     * characters, the order of the characters in a word or words in a line may wrong, due to RTL and LTR marks and
+     * characters!
+     *
+     * Based on http://www.nesterovsky-bros.com/weblog/2013/07/28/VisualToLogicalConversionInJava.aspx
+     *
+     * @param word The word that shall be processed
+     * @return new word with the correct direction of the containing characters
+     */
+    private String handleDirection(String word)
+    {
+        Bidi bidi = new Bidi(word, Bidi.DIRECTION_DEFAULT_LEFT_TO_RIGHT);
+
+        // if there is pure LTR text no need to process further
+        if (!bidi.isMixed() && bidi.getBaseLevel() == Bidi.DIRECTION_LEFT_TO_RIGHT)
+        {
+            return word;
+        }
+
+        // collect individual bidi information
+        int runCount = bidi.getRunCount();
+        byte[] levels = new byte[runCount];
+        Integer[] runs = new Integer[runCount];
+
+        for (int i = 0; i < runCount; i++)
+        {
+            levels[i] = (byte)bidi.getRunLevel(i);
+            runs[i] = i;
+        }
+
+        // reorder individual parts based on their levels
+        Bidi.reorderVisually(levels, 0, runs, 0, runCount);
+
+        // collect the parts based on the direction within the run
+        StringBuilder result = new StringBuilder();
+
+        for (int i = 0; i < runCount; i++)
+        {
+            int index = runs[i];
+            int start = bidi.getRunStart(index);
+            int end = bidi.getRunLimit(index);
+
+            int level = levels[index];
+
+            if ((level & 1) != 0)
+            {
+                while (--end >= start)
+                {
+                    char character = word.charAt(end);
+                    if (Character.isMirrored(word.codePointAt(end)))
+                    {
+                        if (MIRRORING_CHAR_MAP.containsKey(character))
+                        {
+                            result.append(MIRRORING_CHAR_MAP.get(character));
+                        }
+                        else
+                        {
+                            result.append(character);
+                        }
+                    }
+                    else
+                    {
+                        result.append(character);
+                    }
+                }
+            }
+            else
+            {
+                result.append(word, start, end);
+            }
+        }
+
+        return result.toString();
+    }
+
+    private static final Map<Character, Character> MIRRORING_CHAR_MAP = new HashMap<>();
+
+    static
+    {
+        String path = "/org/apache/pdfbox/resources/text/BidiMirroring.txt";
+        try (InputStream resourceAsStream = HeadingAwarePDFTextStripper.class.getResourceAsStream(path);
+             InputStream input = new BufferedInputStream(resourceAsStream))
+        {
+            parseBidiFile(input);
+        }
+        catch (IOException e)
+        {
+            LOG.warn("Could not parse BidiMirroring.txt, mirroring char map will be empty: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * This method parses the bidi file provided as inputstream.
+     *
+     * @param inputStream - The bidi file as inputstream
+     * @throws IOException if any line could not be read by the LineNumberReader
+     */
+    private static void parseBidiFile(InputStream inputStream) throws IOException
+    {
+        LineNumberReader rd = new LineNumberReader(new InputStreamReader(inputStream));
+
+        do
+        {
+            String s = rd.readLine();
+            if (s == null)
+            {
+                break;
+            }
+
+            int comment = s.indexOf('#'); // ignore comments
+            if (comment != -1)
+            {
+                s = s.substring(0, comment);
+            }
+
+            if (s.length() < 2)
+            {
+                continue;
+            }
+
+            StringTokenizer st = new StringTokenizer(s, ";");
+            int nFields = st.countTokens();
+            Character[] fields = new Character[nFields];
+            for (int i = 0; i < nFields; i++)
+            {
+                fields[i] = (char) Integer.parseInt(st.nextToken().trim(), 16);
+            }
+
+            if (fields.length == 2)
+            {
+                // initialize the MIRRORING_CHAR_MAP
+                MIRRORING_CHAR_MAP.put(fields[0], fields[1]);
+            }
+        }
+        while (true);
+    }
+
+    /**
+     * Used within {@link #normalize(List)} to create a single {@link WordWithTextPositions} entry.
+     */
+    private WordWithTextPositions createWord(String word, List<TextPosition> wordPositions)
+    {
+        return new WordWithTextPositions(normalizeWord(word), wordPositions);
+    }
+
+    /**
+     * Normalize certain Unicode characters. For example, convert the single "fi" ligature to "f" and "i". Also
+     * normalises Arabic and Hebrew presentation forms.
+     *
+     * @param word Word to normalize
+     * @return Normalized word
+     */
+    private String normalizeWord(String word)
+    {
+        StringBuilder builder = null;
+        int p = 0;
+        int q = 0;
+        int strLength = word.length();
+        for (; q < strLength; q++)
+        {
+            // We only normalize if the codepoint is in a given range.
+            // Otherwise, NFKC converts too many things that would cause
+            // confusion. For example, it converts the micro symbol in
+            // extended Latin to the value in the Greek script. We normalize
+            // the Unicode Alphabetic and Arabic A&B Presentation forms.
+            char c = word.charAt(q);
+            if (0xFB00 <= c && c <= 0xFDFF || 0xFE70 <= c && c <= 0xFEFF)
+            {
+                if (builder == null)
+                {
+                    builder = new StringBuilder(strLength * 2);
+                }
+                builder.append(word, p, q);
+                // Some fonts map U+FDF2 differently than the Unicode spec.
+                // They add an extra U+0627 character to compensate.
+                // This removes the extra character for those fonts.
+                if (c == 0xFDF2 && q > 0
+                        && (word.charAt(q - 1) == 0x0627 || word.charAt(q - 1) == 0xFE8D))
+                {
+                    builder.append("\u0644\u0644\u0647");
+                }
+                else
+                {
+                    // Trim because some decompositions have an extra space, such as U+FC5E
+                    String normalized = Normalizer.normalize(
+                            word.substring(q, q + 1), Normalizer.Form.NFKC).trim();
+
+                    // Hebrew in Alphabetic Presentation Forms from FB1D to FB4F and
+                    // Arabic Presentation Forms-A from FB50 to FDFF and
+                    // Arabic Presentation Forms-B from FE70 to FEFF
+                    if (0xFB1D <= c && normalized.length() > 1)
+                    {
+                        // Reverse the order of decomposed Hebrew and Arabic letters
+                        normalized = new StringBuilder(normalized).reverse().toString();
+                    }
+                    builder.append(normalized);
+                }
+                p = q + 1;
+            }
+        }
+        if (builder == null)
+        {
+            return handleDirection(word);
+        }
+        else
+        {
+            builder.append(word, p, q);
+            return handleDirection(builder.toString());
+        }
+    }
+
+    /**
+     * Used within {@link #normalize(List)} to handle a {@link TextPosition}.
+     *
+     * @return The StringBuilder that must be used when calling this method.
+     */
+    private StringBuilder normalizeAdd(List<WordWithTextPositions> normalized,
+                                       StringBuilder lineBuilder, List<TextPosition> wordPositions, LineItem item)
+    {
+        if (item.isWordSeparator())
+        {
+            normalized.add(
+                    createWord(lineBuilder.toString(), new ArrayList<>(wordPositions)));
+            lineBuilder = new StringBuilder();
+            wordPositions.clear();
+        }
+        else
+        {
+            TextPosition text = item.getTextPosition();
+            lineBuilder.append(text.getVisuallyOrderedUnicode());
+            wordPositions.add(text);
+        }
+        return lineBuilder;
+    }
+
+    /**
+     * internal marker class. Used as a place holder in a line of TextPositions.
+     */
+    private static final class LineItem
+    {
+        public static final LineItem WORD_SEPARATOR = new LineItem();
+
+        public static LineItem getWordSeparator()
+        {
+            return WORD_SEPARATOR;
+        }
+
+        private final TextPosition textPosition;
+
+        private LineItem()
+        {
+            textPosition = null;
+        }
+
+        LineItem(TextPosition textPosition)
+        {
+            this.textPosition = textPosition;
+        }
+
+        public TextPosition getTextPosition()
+        {
+            return textPosition;
+        }
+
+        public boolean isWordSeparator()
+        {
+            return textPosition == null;
+        }
+    }
+
+    /**
+     * Internal class that maps strings to lists of {@link TextPosition} arrays. Note that the number of entries in that
+     * list may differ from the number of characters in the string due to normalization.
+     *
+     * @author Axel Dörfler
+     */
+    private static final class WordWithTextPositions
+    {
+        final String text;
+        final List<TextPosition> textPositions;
+
+        WordWithTextPositions(String word, List<TextPosition> positions)
+        {
+            text = word;
+            textPositions = positions;
+        }
+
+        public String getText()
+        {
+            return text;
+        }
+
+        public List<TextPosition> getTextPositions()
+        {
+            return textPositions;
+        }
+    }
+
+    /**
+     * wrapper of TextPosition that adds flags to track status as linestart and paragraph start positions.
+     * <p>
+     * This is implemented as a wrapper since the TextPosition class doesn't provide complete access to its state fields
+     * to subclasses. Also, conceptually TextPosition is immutable while these flags need to be set post-creation so it
+     * makes sense to put these flags in this separate class.
+     * </p>
+     *
+     * @author m.martinez@ll.mit.edu
+     */
+    private static final class PositionWrapper
+    {
+        private boolean isLineStart = false;
+        private boolean isParagraphStart = false;
+        private boolean isPageBreak = false;
+        private boolean isHangingIndent = false;
+        private boolean isArticleStart = false;
+
+        private TextPosition position = null;
+
+        /**
+         * Constructs a PositionWrapper around the specified TextPosition object.
+         *
+         * @param position the text position.
+         */
+        PositionWrapper(TextPosition position)
+        {
+            this.position = position;
+        }
+
+        /**
+         * Returns the underlying TextPosition object.
+         *
+         * @return the text position
+         */
+        public TextPosition getTextPosition()
+        {
+            return position;
+        }
+
+        public boolean isLineStart()
+        {
+            return isLineStart;
+        }
+
+        /**
+         * Sets the isLineStart() flag to true.
+         */
+        public void setLineStart()
+        {
+            this.isLineStart = true;
+        }
+
+        public boolean isParagraphStart()
+        {
+            return isParagraphStart;
+        }
+
+        /**
+         * sets the isParagraphStart() flag to true.
+         */
+        public void setParagraphStart()
+        {
+            this.isParagraphStart = true;
+        }
+
+        public boolean isArticleStart()
+        {
+            return isArticleStart;
+        }
+
+        /**
+         * Sets the isArticleStart() flag to true.
+         */
+        public void setArticleStart()
+        {
+            this.isArticleStart = true;
+        }
+
+        public boolean isPageBreak()
+        {
+            return isPageBreak;
+        }
+
+        /**
+         * Sets the isPageBreak() flag to true.
+         */
+        public void setPageBreak()
+        {
+            this.isPageBreak = true;
+        }
+
+        public boolean isHangingIndent()
+        {
+            return isHangingIndent;
+        }
+
+        /**
+         * Sets the isHangingIndent() flag to true.
+         */
+        public void setHangingIndent()
+        {
+            this.isHangingIndent = true;
+        }
+    }
+}

--- a/code/processes/converting-process/test/nu/marginalia/converting/ConvertingIntegrationTest.java
+++ b/code/processes/converting-process/test/nu/marginalia/converting/ConvertingIntegrationTest.java
@@ -6,6 +6,7 @@ import com.google.inject.Injector;
 import nu.marginalia.converting.model.ProcessedDocument;
 import nu.marginalia.converting.processor.DomainProcessor;
 import nu.marginalia.io.SerializableCrawlDataStream;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeDomain;
 import nu.marginalia.model.crawl.DomainIndexingState;
 import nu.marginalia.model.crawl.PubDate;
@@ -13,7 +14,6 @@ import nu.marginalia.model.crawl.UrlIndexingState;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.model.crawldata.CrawledDomain;
 import nu.marginalia.model.crawldata.SerializableCrawlData;
-import nu.marginalia.model.html.HtmlStandard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -91,7 +91,7 @@ public class ConvertingIntegrationTest {
 
             assertTrue(details.title.length() > 4);
             assertTrue(details.description.length() > 4);
-            assertEquals(HtmlStandard.HTML5, details.standard);
+            assertEquals(DocumentFormat.HTML5, details.format);
 
         }
     }
@@ -125,7 +125,7 @@ public class ConvertingIntegrationTest {
             assertTrue(details.metadata.size() > 0);
             assertTrue(details.title.length() > 4);
             assertTrue(details.description.length() > 4);
-            assertEquals(HtmlStandard.HTML5, details.standard);
+            assertEquals(DocumentFormat.HTML5, details.format);
         }
     }
 

--- a/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
+++ b/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
@@ -14,6 +14,7 @@ import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.term_frequency_dict.TermFrequencyDict;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +69,8 @@ class PdfDocumentProcessorPluginTest {
         }
     }
 
+
+    @Disabled
     @Test
     void testingTool() throws Exception {
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample.pdf")).details().title);
@@ -78,6 +81,7 @@ class PdfDocumentProcessorPluginTest {
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample6.pdf")).details().title);
     }
 
+    @Disabled
     @Test
     void testingTool2() throws Exception {
         System.out.println(plugin.convertPdfToHtml(Files.readAllBytes(Path.of("/home/st_work/Work/sample6.pdf"))));

--- a/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
+++ b/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
@@ -1,0 +1,57 @@
+package nu.marginalia.converting.processor.plugin;
+
+import nu.marginalia.WmsaHome;
+import nu.marginalia.converting.model.DisqualifiedException;
+import nu.marginalia.converting.processor.DocumentClass;
+import nu.marginalia.converting.processor.logic.DocumentLengthLogic;
+import nu.marginalia.converting.processor.logic.TitleExtractor;
+import nu.marginalia.converting.processor.plugin.specialization.DefaultSpecialization;
+import nu.marginalia.converting.processor.summary.SummaryExtractor;
+import nu.marginalia.converting.processor.summary.heuristic.*;
+import nu.marginalia.keyword.DocumentKeywordExtractor;
+import nu.marginalia.keyword.LinkTexts;
+import nu.marginalia.language.filter.LanguageFilter;
+import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
+import nu.marginalia.model.crawldata.CrawledDocument;
+import nu.marginalia.term_frequency_dict.TermFrequencyDict;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+class PdfDocumentProcessorPluginTest {
+    static PdfDocumentProcessorPlugin plugin;
+
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+        var lm = WmsaHome.getLanguageModels();
+        plugin = new PdfDocumentProcessorPlugin(255,
+                new LanguageFilter(lm),
+                new ThreadLocalSentenceExtractorProvider(lm),
+                new DocumentKeywordExtractor(new TermFrequencyDict(lm)),
+                new DocumentLengthLogic(100),
+                new DefaultSpecialization(new SummaryExtractor(
+                        255,
+                        new DomFilterHeuristic(255),
+                        new TagDensityHeuristic(255),
+                        new OpenGraphDescriptionHeuristic(),
+                        new MetaDescriptionHeuristic(),
+                        new FallbackHeuristic()
+                ),
+                        new TitleExtractor(255)
+                        ));
+    }
+
+    @Test
+    void createDetails() throws IOException, URISyntaxException, DisqualifiedException {
+        byte[] pdfBytes = Files.readAllBytes(Path.of("/home/st_work/Work/sample.pdf"));
+        var doc = new CrawledDocument("test", "https://www.example.com/sample.pdf", "application/pdf", Instant.now().toString(), 200, "OK", "OK", "", pdfBytes, false, null, null);
+        var details = plugin.createDetails(doc, new LinkTexts(), DocumentClass.NORMAL);
+
+        System.out.println(details);
+    }
+}

--- a/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
+++ b/code/processes/converting-process/test/nu/marginalia/converting/processor/plugin/PdfDocumentProcessorPluginTest.java
@@ -14,7 +14,7 @@ import nu.marginalia.language.sentence.ThreadLocalSentenceExtractorProvider;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.term_frequency_dict.TermFrequencyDict;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 
+@Tag("flaky")
 class PdfDocumentProcessorPluginTest {
     static PdfDocumentProcessorPlugin plugin;
 
@@ -68,18 +69,18 @@ class PdfDocumentProcessorPluginTest {
     }
 
     @Test
-    @Disabled // requires sample PDF files that are not included in the repository
     void testingTool() throws Exception {
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample.pdf")).details().title);
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample2.pdf")).details().title);
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample3.pdf")).details().title);
         System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample4.pdf")).details().title);
+        System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample5.pdf")).details().title);
+        System.out.println(testPdfFile(Path.of("/home/st_work/Work/sample6.pdf")).details().title);
     }
 
     @Test
-    @Disabled
     void testingTool2() throws Exception {
-        System.out.println(plugin.convertPdfToHtml(Files.readAllBytes(Path.of("/home/st_work/Work/sample2.pdf"))));
+        System.out.println(plugin.convertPdfToHtml(Files.readAllBytes(Path.of("/home/st_work/Work/sample6.pdf"))));
     }
 
     @Test

--- a/code/processes/converting-process/test/nu/marginalia/converting/processor/pubdate/PubDateSnifferTest.java
+++ b/code/processes/converting-process/test/nu/marginalia/converting/processor/pubdate/PubDateSnifferTest.java
@@ -3,8 +3,8 @@ package nu.marginalia.converting.processor.pubdate;
 import nu.marginalia.WmsaHome;
 import nu.marginalia.converting.model.DocumentHeaders;
 import nu.marginalia.converting.processor.pubdate.heuristic.PubDateHeuristicDOMParsingPass2;
+import nu.marginalia.model.DocumentFormat;
 import nu.marginalia.model.EdgeUrl;
-import nu.marginalia.model.html.HtmlStandard;
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 
@@ -74,7 +74,7 @@ class PubDateSnifferTest {
                         <time pubdate="pubdate" datetime="2022-08-24">time</time>
                         Wow, sure lor 'em boss
                         </article>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2022-08-24", ret.dateIso8601());
@@ -90,7 +90,7 @@ class PubDateSnifferTest {
                         <time>2022-08-24</time>
                         Wow, sure lor 'em boss
                         </article>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2022-08-24", ret.dateIso8601());
@@ -106,7 +106,7 @@ class PubDateSnifferTest {
                         <time class="published" datetime="July 13, 2006">July 13, 2006</time>
                         Wow, sure lor 'em boss
                         </article>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals(2006, ret.year());
@@ -116,14 +116,14 @@ class PubDateSnifferTest {
     public void testProblemCases() throws IOException, URISyntaxException {
         var ret = dateSniffer.getPubDate(new DocumentHeaders(""),
                 new EdgeUrl("https://www.example.com/"),
-                Jsoup.parse(Files.readString(WmsaHome.getHomePath().resolve("test-data/The Switch to Linux Begins .html"))), HtmlStandard.HTML5, true);
+                Jsoup.parse(Files.readString(WmsaHome.getHomePath().resolve("test-data/The Switch to Linux Begins .html"))), DocumentFormat.HTML5, true);
 
         assertFalse(ret.isEmpty());
         assertEquals(2006, ret.year());
 
         ret = dateSniffer.getPubDate(new DocumentHeaders(""),
                 new EdgeUrl("https://www.example.com/"),
-                Jsoup.parse(Files.readString(WmsaHome.getHomePath().resolve("test-data/Black Hat USA 2010 Understanding and Deploying DNSSEC by Paul Wouters and Patrick Nauber.html"))), HtmlStandard.XHTML, true);
+                Jsoup.parse(Files.readString(WmsaHome.getHomePath().resolve("test-data/Black Hat USA 2010 Understanding and Deploying DNSSEC by Paul Wouters and Patrick Nauber.html"))), DocumentFormat.XHTML, true);
 
         assertFalse(ret.isEmpty());
         assertEquals(2010, ret.year());
@@ -146,7 +146,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <meta itemprop="datePublished" content="2022-08-24" />
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2022-08-24", ret.dateIso8601());
@@ -160,7 +160,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <meta property="datePublished" content="2022-08-24" />
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2022-08-24", ret.dateIso8601());
@@ -174,7 +174,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <script type="application/ld+json">{"@context":"https:\\/\\/schema.org","@type":"Article","name":"In the Year 2525","url":"https:\\/\\/en.wikipedia.org\\/wiki\\/In_the_Year_2525","sameAs":"http:\\/\\/www.wikidata.org\\/entity\\/Q145269","mainEntity":"http:\\/\\/www.wikidata.org\\/entity\\/Q145269","author":{"@type":"Organization","name":"Contributors to Wikimedia projects"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\\/\\/www.wikimedia.org\\/static\\/images\\/wmf-hor-googpub.png"}},"datePublished":"2004-08-24T14:39:14Z","dateModified":"2022-10-20T11:54:37Z","image":"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/4\\/4a\\/In_the_Year_2525_by_Zager_and_Evans_US_vinyl_Side-A_RCA_release.png","headline":"song written and compsoed by Rick Evans, originally recorded by Zager and Evans and released in 1969"}</script><script type="application/ld+json">{"@context":"https:\\/\\/schema.org","@type":"Article","name":"In the Year 2525","url":"https:\\/\\/en.wikipedia.org\\/wiki\\/In_the_Year_2525","sameAs":"http:\\/\\/www.wikidata.org\\/entity\\/Q145269","mainEntity":"http:\\/\\/www.wikidata.org\\/entity\\/Q145269","author":{"@type":"Organization","name":"Contributors to Wikimedia projects"},"publisher":{"@type":"Organization","name":"Wikimedia Foundation, Inc.","logo":{"@type":"ImageObject","url":"https:\\/\\/www.wikimedia.org\\/static\\/images\\/wmf-hor-googpub.png"}},"datePublished":"2004-08-24T14:39:14Z","dateModified":"2022-10-20T11:54:37Z","image":"https:\\/\\/upload.wikimedia.org\\/wikipedia\\/commons\\/4\\/4a\\/In_the_Year_2525_by_Zager_and_Evans_US_vinyl_Side-A_RCA_release.png","headline":"song written and compsoed by Rick Evans, originally recorded by Zager and Evans and released in 1969"}</script>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2004-08-24", ret.dateIso8601());
@@ -188,7 +188,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <script type="application/ld+json" class="aioseop-schema">{"@context":"https://schema.org","@graph":[{"@type":"Organization","@id":"https://socialnomics.net/#organization","url":"https://socialnomics.net/","name":"Socialnomics","sameAs":[]},{"@type":"WebSite","@id":"https://socialnomics.net/#website","url":"https://socialnomics.net/","name":"Socialnomics","publisher":{"@id":"https://socialnomics.net/#organization"}},{"@type":"WebPage","@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#webpage","url":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/","inLanguage":"en-US","name":"3 Reasons Why You Should Adopt Java-based Technology For Your Business","isPartOf":{"@id":"https://socialnomics.net/#website"},"breadcrumb":{"@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#breadcrumblist"},"datePublished":"2016-12-27T21:01:36-06:00","dateModified":"2016-12-22T21:02:32-06:00"},{"@type":"Article","@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#article","isPartOf":{"@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#webpage"},"author":{"@id":"https://socialnomics.net/author/rahis-saifi/#author"},"headline":"3 Reasons Why You Should Adopt Java-based Technology For Your Business","datePublished":"2016-12-27T21:01:36-06:00","dateModified":"2016-12-22T21:02:32-06:00","commentCount":0,"mainEntityOfPage":{"@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#webpage"},"publisher":{"@id":"https://socialnomics.net/#organization"},"articleSection":"Business, business, java, Java Developers, programming languages"},{"@type":"Person","@id":"https://socialnomics.net/author/rahis-saifi/#author","name":"Rahis Saifi","sameAs":["https://www.facebook.com/RahisSaifiOfficial","https://www.twitter.com/57rahis"],"image":{"@type":"ImageObject","@id":"https://socialnomics.net/#personlogo","url":"https://secure.gravatar.com/avatar/e67f630f0b8bc87e59e111d5e955961d?s=96&d=mm&r=g","width":96,"height":96,"caption":"Rahis Saifi"}},{"@type":"BreadcrumbList","@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/#breadcrumblist","itemListElement":[{"@type":"ListItem","position":1,"item":{"@type":"WebPage","@id":"https://socialnomics.net/","url":"https://socialnomics.net/","name":"Socialnomics Blog"}},{"@type":"ListItem","position":2,"item":{"@type":"WebPage","@id":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/","url":"https://socialnomics.net/2016/12/27/3-reasons-why-you-should-adopt-java-based-technology-for-your-business/","name":"3 Reasons Why You Should Adopt Java-based Technology For Your Business"}}]}]}</script>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2016-12-27", ret.dateIso8601());
@@ -202,7 +202,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <title>No date in the HTML</title>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertNull(ret.dateIso8601());
@@ -217,7 +217,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <title>No date in the HTML</title>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertEquals("2022-02-03", ret.dateIso8601());
@@ -232,7 +232,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <p>Published 2003, updated 2022</p>
-                        """), HtmlStandard.HTML5, true);
+                        """), DocumentFormat.HTML5, true);
 
         assertFalse(ret.isEmpty());
         assertNull(ret.dateIso8601());
@@ -258,7 +258,7 @@ class PubDateSnifferTest {
                         <!doctype html>
                         <html>
                         <div style="float: left;">&nbsp;<b>Post subject:</b> Keyboards.</div><div style="float: right;"><span class="postdetails"><b><img src="./styles/subsilver2/imageset/icon_post_target.gif" width="12" height="9" alt="Post" title="Post" /> <a  href="./viewtopic.php?p=34580&amp;sid=cf0c13dedebb4fea1f03fa73e510cd9f#p34580">#1</a></b></span>&nbsp;<b>Posted:</b> Sun Oct 03, 2010 5:37 pm&nbsp;</div>
-                        """), HtmlStandard.UNKNOWN, true);
+                        """), DocumentFormat.UNKNOWN, true);
 
         assertFalse(ret.isEmpty());
         assertNull(ret.dateIso8601());

--- a/code/services-application/api-service/java/nu/marginalia/api/ApiSearchOperator.java
+++ b/code/services-application/api-service/java/nu/marginalia/api/ApiSearchOperator.java
@@ -90,6 +90,7 @@ public class ApiSearchOperator {
                 url.getTitle(),
                 url.getDescription(),
                 sanitizeNaN(url.rankingScore, -100),
+                url.getShortFormat(),
                 details
         );
     }

--- a/code/services-application/api-service/java/nu/marginalia/api/model/ApiSearchResult.java
+++ b/code/services-application/api-service/java/nu/marginalia/api/model/ApiSearchResult.java
@@ -8,14 +8,16 @@ public class ApiSearchResult {
     public String title;
     public String description;
     public double quality;
+    public String format; // "pdf", "html", "text", etc.
 
     public List<List<ApiSearchResultQueryDetails>> details = new ArrayList<>();
 
-    public ApiSearchResult(String url, String title, String description, double quality, List<List<ApiSearchResultQueryDetails>> details) {
+    public ApiSearchResult(String url, String title, String description, double quality, String format, List<List<ApiSearchResultQueryDetails>> details) {
         this.url = url;
         this.title = title;
         this.description = description;
         this.quality = quality;
+        this.format = format;
         this.details = details;
     }
 

--- a/code/services-application/search-service-legacy/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service-legacy/java/nu/marginalia/search/model/UrlDetails.java
@@ -73,6 +73,8 @@ public class UrlDetails implements Comparable<UrlDetails> {
                 return "HTML 5";
             case "PLAIN":
                 return "Plain Text";
+            case "PDF":
+                return "PDF";
             default:
                 return "?";
         }

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
@@ -78,6 +78,8 @@ public class UrlDetails implements Comparable<UrlDetails> {
                 return "HTML 5";
             case "PLAIN":
                 return "Plain Text";
+            case "PDF":
+                return "PDF";
             default:
                 return "?";
         }

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
@@ -94,13 +94,24 @@ public class UrlDetails implements Comparable<UrlDetails> {
     public String displayTitle() {
         StringBuilder sb = new StringBuilder();
 
+        buildDisplayTitle(sb, title);
+
+        if (sb.isEmpty()) {
+            buildDisplayTitle(sb, url.toDisplayString());
+        }
+
+        return sb.toString();
+    }
+
+    private void buildDisplayTitle(StringBuilder sb, String str) {
+
         int distSinceBreak = 0;
 
         char c = ' ';
         int prevC = ' ';
-        for (int i = 0; i < title.length(); i++) {
+        for (int i = 0; i < str.length(); i++) {
             prevC = c;
-            c = title.charAt(i);
+            c = str.charAt(i);
 
             if (Character.isSpaceChar(c)) {
                 distSinceBreak = 0;
@@ -137,8 +148,6 @@ public class UrlDetails implements Comparable<UrlDetails> {
                 sb.append(c);
             }
         }
-
-        return sb.toString();
     }
 
     /** Helper that inserts hyphenation hints and escapes

--- a/code/services-application/search-service/resources/jte/serp/part/result.jte
+++ b/code/services-application/search-service/resources/jte/serp/part/result.jte
@@ -21,6 +21,9 @@
                             </h2>
 
                             <div class="text-sm mt-1">
+                                @if ("PDF".equals(result.first.format))
+                                    <i title="PDF" class="fas fa-file-pdf text-red-500"></i>
+                                @endif
                                 <a class="text-liteblue dark:text-blue-200 underline break-all" href="${result.first.url.toString()}"
                                    rel="noopener noreferrer" tabindex="-1">$unsafe{result.first.displayUrl()}</a>
                             </div>

--- a/code/services-application/search-service/resources/jte/serp/part/result.jte
+++ b/code/services-application/search-service/resources/jte/serp/part/result.jte
@@ -74,6 +74,9 @@
             @if (DocumentFlags.PlainText.isPresent(result.getFirst().resultItem.encodedDocMetadata))
                 <span class="px-1 bg-blue-100 text-blue-700 dark:border dark:border-blue-600 dark:text-blue-400 dark:bg-black  rounded">Plain text</span>
             @endif
+            @if (DocumentFlags.PdfFile.isPresent(result.getFirst().resultItem.encodedDocMetadata))
+                <span class="px-1 bg-blue-100 text-blue-700 dark:border dark:border-blue-600 dark:text-blue-400 dark:bg-black  rounded">PDF File</span>
+            @endif
             @if (DocumentFlags.GeneratorForum.isPresent(result.getFirst().resultItem.encodedDocMetadata))
                 <span class="px-1 bg-blue-100 text-blue-700 dark:border dark:border-blue-600 dark:text-blue-400 dark:bg-black  rounded">Forum</span>
             @endif

--- a/code/services-application/search-service/resources/jte/serp/part/result.jte
+++ b/code/services-application/search-service/resources/jte/serp/part/result.jte
@@ -56,10 +56,13 @@
             <div class="flex mt-2 text-sm flex flex-col space-y-2">
                 <p class="text-black dark:text-white ${result.colorScheme.backgroundColor}  p-1 rounded break-words hyphens-auto">Also from ${result.getDomain().toString()}:</p>
 
-                <ul class="pl-2 mt-2 underline text-liteblue dark:text-blue-200">
+                <ul class="pl-2 mt-2 text-liteblue dark:text-blue-200">
                     @for(UrlDetails item : result.rest)
                         <li class="-indent-4 pl-4 mb-1 break-words hyphens-auto">
-                            <a href="${item.url.toString()}" rel="noopener noreferrer">$unsafe{item.displayTitle()}</a>
+                            @if ("PDF".equals(item.format))
+                                <i title="PDF" class="fas fa-file-pdf text-red-500"></i>
+                            @endif
+                            <a href="${item.url.toString()}" class="underline" rel="noopener noreferrer">$unsafe{item.displayTitle()}</a>
                         </li>
                     @endfor
                 </ul>

--- a/settings.gradle
+++ b/settings.gradle
@@ -244,6 +244,7 @@ dependencyResolutionManagement {
             library('wiremock', 'org.wiremock','wiremock').version('3.11.0')
             library('jte','gg.jte','jte').version('3.1.15')
 
+            library('pdfbox', 'org.apache.pdfbox', 'pdfbox').version('2.0.34')
             bundle('jetty', ['jetty-server', 'jetty-util', 'jetty-servlet'])
 
             bundle('slf4j', ['slf4j.api', 'log4j.api', 'log4j.core', 'log4j.slf4j'])

--- a/settings.gradle
+++ b/settings.gradle
@@ -244,7 +244,7 @@ dependencyResolutionManagement {
             library('wiremock', 'org.wiremock','wiremock').version('3.11.0')
             library('jte','gg.jte','jte').version('3.1.15')
 
-            library('pdfbox', 'org.apache.pdfbox', 'pdfbox').version('2.0.34')
+            library('pdfbox', 'org.apache.pdfbox', 'pdfbox').version('3.0.5')
             bundle('jetty', ['jetty-server', 'jetty-util', 'jetty-servlet'])
 
             bundle('slf4j', ['slf4j.api', 'log4j.api', 'log4j.core', 'log4j.slf4j'])


### PR DESCRIPTION
Add support for processing PDF files.  The changeset adds a dependency on pdfbox, and vendors/modifies its PDFTextStripper to extract additional semantics from the documents. 

Since PDF documents aren't a text based format, but a graphical format which may contain a stream of characters and positions (sometimes overlapping, rotated, out of order) identifying something like a header or a paragraph is a non-trivial task, let alone extracting any text at all.  A number of heuristics are used to try to accomplish this task, they aren't perfect, but about as good as you're going to get without going to something like a vision based LLM, which would be ridiculously expensive to apply at an internet search engine scale.

The change also adds format information to the JSON API, as well as indicators in the GUI for PDF files. 