### PR TITLE
added converter.insertFoundDomains property

### DIFF
--- a/code/execution/java/nu/marginalia/actor/proc/ScrapeFeedsActor.java
+++ b/code/execution/java/nu/marginalia/actor/proc/ScrapeFeedsActor.java
@@ -47,6 +47,8 @@ public class ScrapeFeedsActor extends RecordActorPrototype {
 
     private final Path feedPath = WmsaHome.getHomePath().resolve("data/scrape-urls.txt");
 
+    private static boolean insertFoundDomains = Boolean.getBoolean("converter.insertFoundDomains");
+
     public record Initial() implements ActorStep {}
     @Resume(behavior = ActorResumeBehavior.RETRY)
     public record Wait(String ts) implements ActorStep {}
@@ -138,7 +140,12 @@ public class ScrapeFeedsActor extends RecordActorPrototype {
                 validDomains.add(new EdgeDomain(host));
             }
 
-            insertDomains(validDomains, 0 /* node affinity = 0 means the next index node to run grabs these domains */);
+            if ( true == insertFoundDomains ) {
+                logger.info("Adding found domains");
+                insertDomains(validDomains, 0 /* node affinity = 0 means the next index node to run grabs these domains */);
+            } else {
+                logger.info("Skipping found domains");
+            }
 
             eventLog.logEvent("ScrapeFeedsActor", "Polled " + domainsUrl + " for new domains");
         }

--- a/code/processes/loading-process/java/nu/marginalia/loading/LoaderMain.java
+++ b/code/processes/loading-process/java/nu/marginalia/loading/LoaderMain.java
@@ -40,7 +40,7 @@ public class LoaderMain extends ProcessMainClass {
     private final KeywordLoaderService keywordLoaderService;
     private final DocumentLoaderService documentLoaderService;
 
-    private static boolean insertFoundDomains = Boolean.getBoolean("converter.insertFoundDomains");
+    private static boolean insertFoundDomains = Boolean.getBoolean("loader.insertFoundDomains");
 
     public static void main(String... args) {
         try {

--- a/code/processes/loading-process/java/nu/marginalia/loading/domains/DomainLoaderService.java
+++ b/code/processes/loading-process/java/nu/marginalia/loading/domains/DomainLoaderService.java
@@ -25,7 +25,7 @@ import java.util.Set;
 @Singleton
 public class DomainLoaderService {
 
-    private static boolean insertFoundDomains = Boolean.getBoolean("converter.insertFoundDomains");
+    private static boolean insertFoundDomains = Boolean.getBoolean("loader.insertFoundDomains");
 
     private final HikariDataSource dataSource;
     private final Logger logger = LoggerFactory.getLogger(DomainLoaderService.class);

--- a/code/processes/loading-process/java/nu/marginalia/loading/domains/DomainLoaderService.java
+++ b/code/processes/loading-process/java/nu/marginalia/loading/domains/DomainLoaderService.java
@@ -25,6 +25,8 @@ import java.util.Set;
 @Singleton
 public class DomainLoaderService {
 
+    private static boolean insertFoundDomains = Boolean.getBoolean("converter.insertFoundDomains");
+
     private final HikariDataSource dataSource;
     private final Logger logger = LoggerFactory.getLogger(DomainLoaderService.class);
     private final int nodeId;
@@ -84,25 +86,34 @@ public class DomainLoaderService {
 
             // Add domains that are linked to from the domains we've just crawled, but with -1 affinity meaning they
             // can be grabbed by any index node
-            try (var inserter = new DomainInserter(conn, -1);
-                 var processHeartbeat = heartbeat.createAdHocTaskHeartbeat("INSERT_LINKED_DOMAINS")) {
-                // Add linked domains, but with -1 affinity meaning they can be grabbed by any index node
-                int pageIdx = 0;
+            if ( true == insertFoundDomains ) {
+                logger.info("Adding found domains");
 
-                for (SlopTable.Ref<SlopDomainLinkRecord> page : inputData.listDomainLinkPages()) {
-                    processHeartbeat.progress("INSERT", pageIdx++, domainLinkPageRefs.size());
+                try (var inserter = new DomainInserter(conn, -1);
+                     var processHeartbeat = heartbeat.createAdHocTaskHeartbeat("INSERT_LINKED_DOMAINS")) {
+                    // Add linked domains, but with -1 affinity meaning they can be grabbed by any index node
+                    int pageIdx = 0;
 
-                    try (var reader = new SlopDomainLinkRecord.Reader(page)) {
-                        while (reader.hasMore()) {
-                            SlopDomainLinkRecord record = reader.next();
-                            String domainName = record.dest();
-                            if (domainNamesAll.add(domainName)) {
-                                inserter.accept(new EdgeDomain(domainName));
+                    for (SlopTable.Ref<SlopDomainLinkRecord> page : inputData.listDomainLinkPages()) {
+                        processHeartbeat.progress("INSERT", pageIdx++, domainLinkPageRefs.size());
+
+                        try (var reader = new SlopDomainLinkRecord.Reader(page)) {
+                            while (reader.hasMore()) {
+                                SlopDomainLinkRecord record = reader.next();
+                                String domainName = record.dest();
+                                if (domainNamesAll.add(domainName)) {
+                                    inserter.accept(new EdgeDomain(domainName));
+                                }
                             }
                         }
+   
                     }
                 }
             }
+            else {
+                logger.info("Skipping found domains");
+            }
+
 
             taskHeartbeat.progress(Steps.UPDATE_AFFINITY_AND_IP);
 


### PR DESCRIPTION
This adds the property 'converter.insertFoundDomains', which can be set in the system.properties file; it defaults to 'true'.

If set to 'false', it will prevent the processor from adding found domains to the database.

This change has PRs both on the main MargialiaSearch repo and the docs.marginalia.nu repo.