### PR TITLE
add service to single-service-runner for non-docker users

### DIFF
--- a/code/services-core/single-service-runner/build.gradle
+++ b/code/services-core/single-service-runner/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 
     implementation project(':code:services-core:assistant-service')
 
-    implementation project(':code:services-application:assistant-search')
-    implementation project(':code:services-application:assistant-api')
+    implementation project(':code:services-application:search-service')
+    implementation project(':code:services-application:api-service')
 
     testImplementation libs.bundles.slf4j.test
     testImplementation libs.bundles.junit

--- a/code/services-core/single-service-runner/build.gradle
+++ b/code/services-core/single-service-runner/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 
     implementation project(':code:services-core:assistant-service')
 
+    implementation project(':code:services-application:assistant-sarch')
+    implementation project(':code:services-application:assistant-api')
+
     testImplementation libs.bundles.slf4j.test
     testImplementation libs.bundles.junit
     testImplementation libs.mockito

--- a/code/services-core/single-service-runner/build.gradle
+++ b/code/services-core/single-service-runner/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     implementation project(':code:services-core:assistant-service')
 
-    implementation project(':code:services-application:assistant-sarch')
+    implementation project(':code:services-application:assistant-search')
     implementation project(':code:services-application:assistant-api')
 
     testImplementation libs.bundles.slf4j.test

--- a/code/services-core/single-service-runner/build.gradle
+++ b/code/services-core/single-service-runner/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation project(':code:services-core:control-service')
     implementation project(':code:services-core:executor-service')
 
+    implementation project(':code:services-core:assistant-service')
+
     testImplementation libs.bundles.slf4j.test
     testImplementation libs.bundles.junit
     testImplementation libs.mockito

--- a/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
+++ b/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
@@ -84,6 +84,8 @@ public class SingleService {
         ControlService("control", "nu.marginalia.control.ControlMain"),
         ExecutorService("executor", "nu.marginalia.executor.ExecutorMain"),
         QueryService("query", "nu.marginalia.query.QueryMain"),
+
+        QueryService("assistant", "nu.marginalia.assistant.AssistantMain"),
         ;
 
         public final String name;

--- a/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
+++ b/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
@@ -85,7 +85,7 @@ public class SingleService {
         ExecutorService("executor", "nu.marginalia.executor.ExecutorMain"),
         QueryService("query", "nu.marginalia.query.QueryMain"),
 
-        QueryService("assistant", "nu.marginalia.assistant.AssistantMain"),
+        AssitantService("assistant", "nu.marginalia.assistant.AssistantMain"),
         ;
 
         public final String name;

--- a/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
+++ b/code/services-core/single-service-runner/java/nu/marginalia/SingleService.java
@@ -86,6 +86,9 @@ public class SingleService {
         QueryService("query", "nu.marginalia.query.QueryMain"),
 
         AssitantService("assistant", "nu.marginalia.assistant.AssistantMain"),
+
+        SearchService("search", "nu.marginalia.search.SearchMain"),
+        ApiService("api", "nu.marginalia.api.ApiMain"),
         ;
 
         public final String name;


### PR DESCRIPTION
This enables the following services for launch from the single-service-runner:

* services-core/assistant
* services-application/search
* services-application/api

There are extraneous commits because I'm a terrible typist.

The services launch, though I am able to start looking into whether they actually function now that they're in the runner.  :-)