### PR TITLE
(WIP) Evaluate uncompressed spans files

### DIFF
--- a/code/index/index-forward/java/nu/marginalia/index/forward/ForwardIndexReader.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/ForwardIndexReader.java
@@ -4,6 +4,7 @@ import nu.marginalia.array.LongArray;
 import nu.marginalia.array.LongArrayFactory;
 import nu.marginalia.index.forward.spans.DocumentSpans;
 import nu.marginalia.index.forward.spans.ForwardIndexSpansReader;
+import nu.marginalia.index.forward.spans.PlainForwardIndexSpansReader;
 import nu.marginalia.model.id.UrlIdCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +65,7 @@ public class ForwardIndexReader {
 
         ids = loadIds(idsFile);
         data = loadData(dataFile);
-        spansReader = new ForwardIndexSpansReader(spansFile);
+        spansReader = new PlainForwardIndexSpansReader(spansFile);
     }
 
     private static LongArray loadIds(Path idsFile) throws IOException {

--- a/code/index/index-forward/java/nu/marginalia/index/forward/spans/CompressedForwardIndexSpansReader.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/spans/CompressedForwardIndexSpansReader.java
@@ -1,0 +1,59 @@
+package nu.marginalia.index.forward.spans;
+
+import nu.marginalia.sequence.VarintCodedSequence;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+@SuppressWarnings("preview")
+public class CompressedForwardIndexSpansReader implements AutoCloseable, ForwardIndexSpansReader {
+    private final FileChannel spansFileChannel;
+
+    public CompressedForwardIndexSpansReader(Path spansFile) throws IOException {
+        this.spansFileChannel = (FileChannel) Files.newByteChannel(spansFile, StandardOpenOption.READ);
+    }
+
+    public DocumentSpans readSpans(Arena arena, long encodedOffset) throws IOException {
+        // Decode the size and offset from the encoded offset
+        long size = SpansCodec.decodeSize(encodedOffset);
+        long offset = SpansCodec.decodeStartOffset(encodedOffset);
+
+        // Allocate a buffer from the arena
+        var buffer = arena.allocate(size).asByteBuffer();
+        buffer.clear();
+        while (buffer.hasRemaining()) {
+            spansFileChannel.read(buffer, offset + buffer.position());
+        }
+        buffer.flip();
+
+        // Read the number of spans in the document
+        int count = buffer.get();
+
+        DocumentSpans ret = new DocumentSpans();
+
+        // Decode each span
+        while (count-- > 0) {
+            byte code = buffer.get();
+            short len = buffer.getShort();
+
+            ByteBuffer data = buffer.slice(buffer.position(), len);
+            ret.accept(code, new VarintCodedSequence(data));
+
+            // Reset the buffer position to the end of the span
+            buffer.position(buffer.position() + len);
+        }
+
+        return ret;
+    }
+
+    @Override
+    public void close() throws IOException {
+        spansFileChannel.close();
+    }
+
+}

--- a/code/index/index-forward/java/nu/marginalia/index/forward/spans/DocumentSpan.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/spans/DocumentSpan.java
@@ -11,6 +11,9 @@ public class DocumentSpan {
     /** A list of the interlaced start and end positions of each span in the document of this type */
     private final IntList startsEnds;
 
+    public DocumentSpan(IntList startsEnds) {
+        this.startsEnds = startsEnds;
+    }
     public DocumentSpan(CodedSequence startsEnds) {
         this.startsEnds = startsEnds.values();
     }

--- a/code/index/index-forward/java/nu/marginalia/index/forward/spans/DocumentSpans.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/spans/DocumentSpans.java
@@ -1,5 +1,6 @@
 package nu.marginalia.index.forward.spans;
 
+import it.unimi.dsi.fastutil.ints.IntList;
 import nu.marginalia.language.sentence.tag.HtmlTag;
 import nu.marginalia.sequence.CodedSequence;
 
@@ -37,6 +38,23 @@ public class DocumentSpans {
             return body;
 
         return EMPTY_SPAN;
+    }
+
+    void accept(byte code, IntList positions) {
+        if (code == HtmlTag.HEADING.code)
+            this.heading = new DocumentSpan(positions);
+        else if (code == HtmlTag.TITLE.code)
+            this.title = new DocumentSpan(positions);
+        else if (code == HtmlTag.NAV.code)
+            this.nav = new DocumentSpan(positions);
+        else if (code == HtmlTag.CODE.code)
+            this.code = new DocumentSpan(positions);
+        else if (code == HtmlTag.ANCHOR.code)
+            this.anchor = new DocumentSpan(positions);
+        else if (code == HtmlTag.EXTERNAL_LINKTEXT.code)
+            this.externalLinkText = new DocumentSpan(positions);
+        else if (code == HtmlTag.BODY.code)
+            this.body = new DocumentSpan(positions);
     }
 
     void accept(byte code, CodedSequence positions) {

--- a/code/index/index-forward/java/nu/marginalia/index/forward/spans/ForwardIndexSpansReader.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/spans/ForwardIndexSpansReader.java
@@ -1,59 +1,8 @@
 package nu.marginalia.index.forward.spans;
 
-import nu.marginalia.sequence.VarintCodedSequence;
-
 import java.io.IOException;
 import java.lang.foreign.Arena;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
-@SuppressWarnings("preview")
-public class ForwardIndexSpansReader implements AutoCloseable {
-    private final FileChannel spansFileChannel;
-
-    public ForwardIndexSpansReader(Path spansFile) throws IOException {
-        this.spansFileChannel = (FileChannel) Files.newByteChannel(spansFile, StandardOpenOption.READ);
-    }
-
-    public DocumentSpans readSpans(Arena arena, long encodedOffset) throws IOException {
-        // Decode the size and offset from the encoded offset
-        long size = SpansCodec.decodeSize(encodedOffset);
-        long offset = SpansCodec.decodeStartOffset(encodedOffset);
-
-        // Allocate a buffer from the arena
-        var buffer = arena.allocate(size).asByteBuffer();
-        buffer.clear();
-        while (buffer.hasRemaining()) {
-            spansFileChannel.read(buffer, offset + buffer.position());
-        }
-        buffer.flip();
-
-        // Read the number of spans in the document
-        int count = buffer.get();
-
-        DocumentSpans ret = new DocumentSpans();
-
-        // Decode each span
-        while (count-- > 0) {
-            byte code = buffer.get();
-            short len = buffer.getShort();
-
-            ByteBuffer data = buffer.slice(buffer.position(), len);
-            ret.accept(code, new VarintCodedSequence(data));
-
-            // Reset the buffer position to the end of the span
-            buffer.position(buffer.position() + len);
-        }
-
-        return ret;
-    }
-
-    @Override
-    public void close() throws IOException {
-        spansFileChannel.close();
-    }
-
+public interface ForwardIndexSpansReader extends AutoCloseable {
+    DocumentSpans readSpans(Arena arena, long encodedOffset) throws IOException;
 }

--- a/code/index/index-forward/java/nu/marginalia/index/forward/spans/PlainForwardIndexSpansReader.java
+++ b/code/index/index-forward/java/nu/marginalia/index/forward/spans/PlainForwardIndexSpansReader.java
@@ -1,0 +1,59 @@
+package nu.marginalia.index.forward.spans;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+@SuppressWarnings("preview")
+public class PlainForwardIndexSpansReader implements ForwardIndexSpansReader {
+    private final FileChannel spansFileChannel;
+
+    public PlainForwardIndexSpansReader(Path spansFile) throws IOException {
+        this.spansFileChannel = (FileChannel) Files.newByteChannel(spansFile, StandardOpenOption.READ);
+    }
+
+    @Override
+    public DocumentSpans readSpans(Arena arena, long encodedOffset) throws IOException {
+        // Decode the size and offset from the encoded offset
+        long size = SpansCodec.decodeSize(encodedOffset);
+        long offset = SpansCodec.decodeStartOffset(encodedOffset);
+
+        // Allocate a buffer from the arena
+        var buffer = arena.allocate(size).asByteBuffer();
+        buffer.clear();
+        while (buffer.hasRemaining()) {
+            spansFileChannel.read(buffer, offset + buffer.position());
+        }
+        buffer.flip();
+
+        // Read the number of spans in the document
+        int count = buffer.get();
+
+        DocumentSpans ret = new DocumentSpans();
+
+        // Decode each span
+        while (count-- > 0) {
+            byte code = buffer.get();
+            short len = buffer.getShort();
+
+            IntArrayList values = new IntArrayList(len);
+            while (len-- > 0) {
+                values.add(buffer.getInt());
+            }
+            ret.accept(code, values);
+        }
+
+        return ret;
+    }
+
+    @Override
+    public void close() throws IOException {
+        spansFileChannel.close();
+    }
+
+}

--- a/code/index/index-forward/test/nu/marginalia/index/forward/ForwardIndexSpansReaderTest.java
+++ b/code/index/index-forward/test/nu/marginalia/index/forward/ForwardIndexSpansReaderTest.java
@@ -1,7 +1,7 @@
 package nu.marginalia.index.forward;
 
 import it.unimi.dsi.fastutil.ints.IntList;
-import nu.marginalia.index.forward.spans.ForwardIndexSpansReader;
+import nu.marginalia.index.forward.spans.CompressedForwardIndexSpansReader;
 import nu.marginalia.index.forward.spans.ForwardIndexSpansWriter;
 import nu.marginalia.language.sentence.tag.HtmlTag;
 import nu.marginalia.sequence.VarintCodedSequence;
@@ -46,7 +46,7 @@ class ForwardIndexSpansReaderTest {
             offset2 = writer.endRecord();
         }
 
-        try (var reader = new ForwardIndexSpansReader(testFile);
+        try (var reader = new CompressedForwardIndexSpansReader(testFile);
              var arena = Arena.ofConfined()
         ) {
             var spans1 = reader.readSpans(arena, offset1);
@@ -83,7 +83,7 @@ class ForwardIndexSpansReaderTest {
             offset1 = writer.endRecord();
         }
 
-        try (var reader = new ForwardIndexSpansReader(testFile);
+        try (var reader = new CompressedForwardIndexSpansReader(testFile);
              var arena = Arena.ofConfined()
         ) {
             var spans1 = reader.readSpans(arena, offset1);
@@ -110,7 +110,7 @@ class ForwardIndexSpansReaderTest {
             offset1 = writer.endRecord();
         }
 
-        try (var reader = new ForwardIndexSpansReader(testFile);
+        try (var reader = new CompressedForwardIndexSpansReader(testFile);
              var arena = Arena.ofConfined()
         ) {
             var spans1 = reader.readSpans(arena, offset1);
@@ -137,7 +137,7 @@ class ForwardIndexSpansReaderTest {
             offset1 = writer.endRecord();
         }
 
-        try (var reader = new ForwardIndexSpansReader(testFile);
+        try (var reader = new CompressedForwardIndexSpansReader(testFile);
              var arena = Arena.ofConfined()
         ) {
             var spans1 = reader.readSpans(arena, offset1);


### PR DESCRIPTION
Span decompression appears to be somewhat of a performance bottleneck.  This change removes compression of the spans file.  The spans are still compressed in transit between the converter and index constructor at this stage.  The change is intentionally kept small to just evaluate the performance implications, change in file sizes, etc.

Before the change file sizes in pre-production was
```
159M	fwd-doc-data.dat
53M	fwd-doc-id.dat
214M	fwd-spans.dat
35G	rev-docs.dat
9.3G	rev-positions.dat
1.4G	rev-prio-docs.dat
806M	rev-prio-words.dat
1.5G	rev-words.dat
48G	total
```
