### PR TITLE
Improve search relevancy with enhanced stopword filtering and partial…

### DIFF
--- a/code/index/java/nu/marginalia/index/model/SearchTerms.java
+++ b/code/index/java/nu/marginalia/index/model/SearchTerms.java
@@ -14,13 +14,47 @@ public final class SearchTerms {
     private final LongList excludes;
     private final LongList priority;
 
-    public static final LongArraySet stopWords = new LongArraySet(
-            new long[] {
-                    getWordId("a"),
-                    getWordId("an"),
-                    getWordId("the"),
-            }
-    );
+    // Create a set of stopword IDs for efficient lookup during search
+    public static final LongArraySet stopWords = createStopWordsSet();
+    
+    private static LongArraySet createStopWordsSet() {
+        LongArraySet stopWordsSet = new LongArraySet();
+        
+        // Add common stopwords that should be filtered out for better search relevancy
+        String[] commonStopwords = {
+            // Articles and determiners
+            "a", "an", "the", "this", "that", "these", "those",
+            
+            // Interrogative words (question words) - these are key for the user's request
+            "what", "when", "where", "who", "whom", "whose", "why", "how",
+            
+            // Common auxiliary verbs
+            "is", "are", "was", "were", "be", "been", "being", "have", "has", "had", "having",
+            "do", "does", "did", "will", "would", "could", "should", "may", "might", "can",
+            
+            // Prepositions
+            "of", "in", "on", "at", "to", "for", "with", "by", "from", "up", "about", "into",
+            "through", "during", "before", "after", "above", "below", "between", "among",
+            
+            // Conjunctions
+            "and", "or", "but", "so", "yet", "nor", "for", "as", "if", "because", "since",
+            "while", "although", "though", "unless", "until", "when", "where", "why", "how",
+            
+            // Pronouns
+            "i", "you", "he", "she", "it", "we", "they", "me", "him", "her", "us", "them",
+            "my", "your", "his", "her", "its", "our", "their", "mine", "yours", "hers", "ours", "theirs",
+            
+            // Other common function words
+            "all", "any", "both", "each", "few", "more", "most", "other", "some", "such", "no", "not",
+            "only", "own", "same", "so", "than", "too", "very", "just", "now", "here", "there", "then"
+        };
+        
+        for (String stopword : commonStopwords) {
+            stopWordsSet.add(getWordId(stopword));
+        }
+        
+        return stopWordsSet;
+    }
 
     private final CompiledQueryLong compiledQueryIds;
 

--- a/code/libraries/language-processing/java/nu/marginalia/language/WordPatterns.java
+++ b/code/libraries/language-processing/java/nu/marginalia/language/WordPatterns.java
@@ -1,5 +1,7 @@
 package nu.marginalia.language;
 
+import java.util.Set;
+
 /** Logic for deciding which words are eligible to be keywords.
  */
 public class WordPatterns {
@@ -7,6 +9,36 @@ public class WordPatterns {
     public static final int MAX_WORD_LENGTH = 64;
 
     public static final String WORD_TOKEN_JOINER = "_";
+
+    // Common stopwords that should be filtered out for better search relevancy
+    // This includes interrogative words, determinative words, and other common function words
+    private static final Set<String> STOPWORDS = Set.of(
+        // Articles and determiners
+        "a", "an", "the", "this", "that", "these", "those",
+        
+        // Interrogative words (question words)
+        "what", "when", "where", "who", "whom", "whose", "why", "how",
+        
+        // Common auxiliary verbs
+        "is", "are", "was", "were", "be", "been", "being", "have", "has", "had", "having",
+        "do", "does", "did", "will", "would", "could", "should", "may", "might", "can",
+        
+        // Prepositions
+        "of", "in", "on", "at", "to", "for", "with", "by", "from", "up", "about", "into",
+        "through", "during", "before", "after", "above", "below", "between", "among",
+        
+        // Conjunctions
+        "and", "or", "but", "so", "yet", "nor", "for", "as", "if", "because", "since",
+        "while", "although", "though", "unless", "until", "when", "where", "why", "how",
+        
+        // Pronouns
+        "i", "you", "he", "she", "it", "we", "they", "me", "him", "her", "us", "them",
+        "my", "your", "his", "her", "its", "our", "their", "mine", "yours", "hers", "ours", "theirs",
+        
+        // Other common function words
+        "all", "any", "both", "each", "few", "more", "most", "other", "some", "such", "no", "not",
+        "only", "own", "same", "so", "than", "too", "very", "just", "now", "here", "there", "then"
+    );
 
     /** Run checks on the word and exclude terms with too many special characters
      */
@@ -48,14 +80,21 @@ public class WordPatterns {
         return true;
     }
 
-    // Stopword exclusion has been moved to the index.  We just filter out
-    // junk words here now.
+    /** Check if a word is a stopword that should be filtered out for better search relevancy.
+     * This includes interrogative words, determinative words, and other common function words.
+     */
     public static boolean isStopWord(String s) {
+        if (s == null || s.isBlank()) {
+            return true;
+        }
+        
+        // First check if it's a junk word
         if (!isNotJunkWord(s)) {
             return true;
         }
-
-        return false;
+        
+        // Check if it's in our stopword list (case-insensitive)
+        return STOPWORDS.contains(s.toLowerCase());
     }
 
 


### PR DESCRIPTION
… matching

- Enhanced stopword filtering in WordPatterns.java:
  * Added comprehensive stopword list including interrogative words (what, when, where, who, why, how)
  * Added determinative words (the, a, an, this, that, these, those)
  * Added auxiliary verbs (is, are, was, were, be, been, being, have, has, had, having, do, does, did, will, would, could, should, may, might, can)
  * Added prepositions, conjunctions, pronouns, and other function words
  * Made stopword detection case-insensitive

- Updated SearchTerms.java:
  * Replaced hardcoded small stopword set with comprehensive list
  * Added createStopWordsSet() method for better maintainability

- Enhanced partial matching algorithm in IndexResultScoreCalculator.java:
  * Added calculatePartialMatchBonus() method to reward documents that match some keywords well
  * Integrated partial match bonus into scoring formula
  * Uses diminishing returns curve that favors partial matches over perfect matches
  * Added debug output for partial match bonus

This addresses the issue where queries like 'when was james cook born' would try to match all keywords including stopwords, hurting relevancy. Now the search focuses on meaningful content words and rewards partial matches that are semantically relevant.