### PR TITLE
Compressed warc entries

### DIFF
--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/HttpFetcherImpl.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/HttpFetcherImpl.java
@@ -566,12 +566,16 @@ public class HttpFetcherImpl implements HttpFetcher, HttpRequestRetryStrategy {
                         entityStream = new GZIPInputStream(entityStream);
                     }
 
-                    Document parsedSitemap = Jsoup.parse(
-                            entityStream,
-                            null,
-                            sitemapUrl.toString(),
-                            Parser.xmlParser()
-                    );
+                    Document parsedSitemap;
+
+                    try (var stream = entityStream) {
+                        parsedSitemap = Jsoup.parse(
+                                stream,
+                                null,
+                                sitemapUrl.toString(),
+                                Parser.xmlParser()
+                        );
+                    }
 
                     if (parsedSitemap.childrenSize() == 0) {
                         return new SitemapResult.SitemapError();

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/HttpFetcherImpl.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/HttpFetcherImpl.java
@@ -315,7 +315,7 @@ public class HttpFetcherImpl implements HttpFetcher, HttpRequestRetryStrategy {
                 return new DomainProbeResult.Error(CrawlerDomainStatus.ERROR, "Timeout during domain probe");
             }
             catch (Exception ex) {
-                return new DomainProbeResult.Error(CrawlerDomainStatus.ERROR, ex.getClass().getSimpleName() + " during domain probe ");
+                return new DomainProbeResult.Error(CrawlerDomainStatus.ERROR, ex.getClass().getSimpleName() + " during domain probe");
             }
 
         }

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
@@ -66,10 +66,13 @@ public abstract class WarcInputBuffer implements AutoCloseable {
             if (length == 0) {
                 return new ErrorBuffer();
             }
-            if (length < 8192) {
+
+            if (length > 0 && length < 8192) {
                 return new MemoryBuffer(response.getHeaders(), request, timeLimit, is, (int) length);
             }
             else {
+                // handles both the negative length case (e.g. HTTP 1.0)
+                // and the known length case
                 return new FileBuffer(response.getHeaders(), request, timeLimit, is, tempDir);
             }
         }

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
@@ -13,9 +13,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.zip.GZIPInputStream;
-
-import static nu.marginalia.crawl.fetcher.warc.ErrorBuffer.suppressContentEncoding;
 
 /** Input buffer for temporary storage of a HTTP response
  *  This may be in-memory or on-disk, at the discretion of
@@ -64,19 +61,15 @@ public abstract class WarcInputBuffer implements AutoCloseable {
         try {
             is = entity.getContent();
 
-            boolean isGzipEncoded = isContentEncodingGzip(response);
-            if (isGzipEncoded) {
-                is = new GZIPInputStream(is);
-            }
-
             long length = entity.getContentLength();
 
-            if (!isGzipEncoded && length > 0 && length < 8192) {
-                // If the content is small and not compressed, we can just read it into memory
+            if (length == 0) {
+                return new ErrorBuffer();
+            }
+            if (length < 8192) {
                 return new MemoryBuffer(response.getHeaders(), request, timeLimit, is, (int) length);
-            } else {
-                // For compressed responses we always use a file buffer since the
-                // Content-Length reflects the compressed size, not the decompressed size
+            }
+            else {
                 return new FileBuffer(response.getHeaders(), request, timeLimit, is, tempDir);
             }
         }
@@ -161,11 +154,6 @@ public abstract class WarcInputBuffer implements AutoCloseable {
             }
         }
 
-    }
-
-    private static boolean isContentEncodingGzip(ClassicHttpResponse response) {
-        Header header = response.getFirstHeader("Content-Encoding");
-        return header != null && "gzip".equalsIgnoreCase(header.getValue());
     }
 
     /** Takes a Content-Range header and checks if it is complete.
@@ -267,7 +255,7 @@ class ErrorBuffer extends WarcInputBuffer {
 class MemoryBuffer extends WarcInputBuffer {
     byte[] data;
     public MemoryBuffer(Header[] headers, HttpGet request, Duration timeLimit, InputStream responseStream, int size) {
-        super(suppressContentEncoding(headers));
+        super(headers);
 
         if (!isRangeComplete(headers)) {
             truncationReason = WarcTruncationReason.LENGTH;
@@ -302,7 +290,7 @@ class FileBuffer extends WarcInputBuffer {
     private final Path tempFile;
 
     public FileBuffer(Header[] headers, HttpGet request, Duration timeLimit, InputStream responseStream, Path tempDir) throws IOException {
-        super(suppressContentEncoding(headers));
+        super(headers);
 
         if (!isRangeComplete(headers)) {
             truncationReason = WarcTruncationReason.LENGTH;

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcProtocolReconstructor.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcProtocolReconstructor.java
@@ -171,12 +171,9 @@ public class WarcProtocolReconstructor {
             if (headerCapitalized.startsWith("X-Marginalia"))
                 continue;
 
-            // Omit Transfer-Encoding and Content-Encoding headers
+            // Omit Transfer-Encoding
             if (headerCapitalized.equals("Transfer-Encoding"))
                 continue;
-            if (headerCapitalized.equals("Content-Encoding"))
-                continue;
-
 
             // Since we're transparently decoding gzip, we need to update the Content-Length header
             // to reflect the actual size of the response body. We'll do this at the end.
@@ -202,10 +199,8 @@ public class WarcProtocolReconstructor {
             if (headerCapitalized.startsWith("X-Marginalia"))
                 return;
 
-            // Omit Transfer-Encoding and Content-Encoding headers
+            // Omit Transfer-Encoding
             if (headerCapitalized.equals("Transfer-Encoding"))
-                return;
-            if (headerCapitalized.equals("Content-Encoding"))
                 return;
 
             // Since we're transparently decoding gzip, we need to update the Content-Length header

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcRecorder.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcRecorder.java
@@ -16,6 +16,7 @@ import org.netpreserve.jwarc.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -29,6 +30,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
+import java.util.zip.GZIPInputStream;
 
 /** Based on JWarc's fetch method, APL 2.0 license
  * <p></p>
@@ -40,7 +42,7 @@ public class WarcRecorder implements AutoCloseable {
     /** Maximum time we'll wait on a single request */
     static final int MAX_TIME = 30_000;
 
-    /** Maximum (decompressed) size we'll save */
+    /** Maximum size we'll save */
     static final int MAX_SIZE = Integer.getInteger("crawler.maxFetchSize", 32 * 1024 * 1024);
 
     private final WarcWriter writer;
@@ -223,14 +225,16 @@ public class WarcRecorder implements AutoCloseable {
                         }
                     }
 
+                    try (ByteArrayInputStream stream = new ByteArrayInputStream(
+                            responseDataBuffer.data, dataStart,
+                            responseDataBuffer.length() - dataStart)) {
 
-                    return new HttpFetchResult.ResultOk(responseUri,
-                            response.getCode(),
-                            inputBuffer.headers(),
-                            inetAddress.getHostAddress(),
-                            responseDataBuffer.data,
-                            dataStart,
-                            responseDataBuffer.length() - dataStart);
+                        return HttpFetchResult.ResultOk.forStreamedBytes(responseUri,
+                                response.getCode(),
+                                inputBuffer.headers(),
+                                inetAddress.getHostAddress(),
+                                stream);
+                    }
                 } catch (Exception ex) {
                     flagAsError(new EdgeUrl(requestUri), ex); // write a WARC record to indicate the error
                     logger.warn("Failed to fetch URL {}:  {}", requestUri, ex.getMessage());

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcRecorder.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcRecorder.java
@@ -30,7 +30,6 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.zip.GZIPInputStream;
 
 /** Based on JWarc's fetch method, APL 2.0 license
  * <p></p>

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/retreival/revisit/DocumentWithReference.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/retreival/revisit/DocumentWithReference.java
@@ -36,7 +36,7 @@ public record DocumentWithReference(
             return false;
         if (doc.documentBodyBytes.length == 0) {
             if (doc.httpStatus < 300) {
-                return resultOk.bytesLength() == 0;
+                return resultOk.byteLength() == 0;
             }
             else if (doc.httpStatus == 301 || doc.httpStatus == 302 || doc.httpStatus == 307) {
                 @Nullable

--- a/code/processes/crawling-process/model/java/nu/marginalia/model/body/DocumentBodyExtractor.java
+++ b/code/processes/crawling-process/model/java/nu/marginalia/model/body/DocumentBodyExtractor.java
@@ -51,10 +51,9 @@ public class DocumentBodyExtractor {
     /** Extract the body from a fetch result as a byte array. */
     public static DocumentBodyResult<byte[]> asBytes(HttpFetchResult.ResultOk rsp) {
         try {
-            var byteStream = rsp.getInputStream();
             var contentTypeHeader = rsp.header("Content-Type");
 
-            byte[] data = byteStream.readAllBytes(); // size is limited by WarcRecorder
+            byte[] data = rsp.bytes();
             var contentType = ContentTypeParser.parseContentType(contentTypeHeader, data);
 
             return new DocumentBodyResult.Ok<>(contentType, data);

--- a/code/processes/crawling-process/model/java/nu/marginalia/model/body/HttpFetchResult.java
+++ b/code/processes/crawling-process/model/java/nu/marginalia/model/body/HttpFetchResult.java
@@ -7,16 +7,15 @@ import org.apache.hc.core5.http.message.BasicHeader;
 import org.jetbrains.annotations.Nullable;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.netpreserve.jwarc.MessageHeaders;
 import org.netpreserve.jwarc.WarcResponse;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
 import java.net.InetAddress;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 
 /* FIXME:  This interface has a very unfortunate name that is not very descriptive.
@@ -25,27 +24,37 @@ public sealed interface HttpFetchResult {
 
     boolean isOk();
 
+    final int MAX_BODY_SIZE = Integer.getInteger("crawler.maxFetchSize", 32 * 1024 * 1024);
+
     /** Convert a WarcResponse to a HttpFetchResult */
     static HttpFetchResult importWarc(WarcResponse response) {
         try {
             var http = response.http();
 
             try (var body = http.body()) {
-                byte[] bytes = body.stream().readAllBytes();
-
                 String ipAddress = response
                         .ipAddress()
                         .map(InetAddress::getHostAddress)
                         .orElse("");
 
-                return new ResultOk(
+                Header[] headers = http.headers().map().entrySet().stream()
+                        .mapMulti((entry, c) -> {
+                            String key = entry.getKey();
+                            if (key.isBlank()) return;
+                            if (!Character.isAlphabetic(key.charAt(0))) return;
+
+                            for (var val : entry.getValue()) {
+                                c.accept(new BasicHeader(key, val));
+                            }
+                        })
+                        .toArray(Header[]::new);
+
+                return ResultOk.forStreamedBytes(
                         response.targetURI(),
                         http.status(),
-                        http.headers(),
+                        headers,
                         ipAddress,
-                        bytes,
-                        0,
-                        bytes.length
+                        body.stream()
                 );
             }
         }
@@ -63,28 +72,33 @@ public sealed interface HttpFetchResult {
                     int statusCode,
                     Header[] headers,
                     String ipAddress,
-                    byte[] bytesRaw, // raw data for the entire response including headers
-                    int bytesStart,
-                    int bytesLength
+                    byte[] bytes
     ) implements HttpFetchResult {
 
-        public ResultOk(URI uri, int status, MessageHeaders headers, String ipAddress, byte[] bytes, int bytesStart, int length) {
-            this(uri, status, convertHeaders(headers), ipAddress, bytes, bytesStart, length);
-        }
+        public static ResultOk forStreamedBytes(URI uri,
+                                                int statusCode,
+                                                Header[] headers,
+                                                String ipAddress,
+                                                InputStream stream) throws IOException {
+            boolean isGzip = false;
 
-        private static Header[] convertHeaders(MessageHeaders messageHeaders) {
-            List<Header> headers = new ArrayList<>(12);
+            for (var header : headers) {
+                if ("Content-Encoding".equalsIgnoreCase(header.getName())) {
+                    isGzip = "gzip".equalsIgnoreCase(header.getValue());
 
-            messageHeaders.map().forEach((k, v) -> {
-                if (k.isBlank()) return;
-                if (!Character.isAlphabetic(k.charAt(0))) return;
+                    // Reconstruct a clean header array that doesn't claim the data is compressed
+                    headers = Arrays.stream(headers)
+                            .filter(h -> h != header)
+                            .toArray(Header[]::new);
 
-                for (var value : v) {
-                    headers.add(new BasicHeader(k, value));
+                    break;
                 }
-            });
+            }
 
-            return headers.toArray(new Header[0]);
+            if (isGzip) stream = new GZIPInputStream(stream);
+            byte[] bytes = stream.readNBytes(MAX_BODY_SIZE);
+
+            return new ResultOk(uri, statusCode, headers, ipAddress, bytes);
         }
 
         public boolean isOk() {
@@ -92,13 +106,11 @@ public sealed interface HttpFetchResult {
         }
 
         public InputStream getInputStream() {
-            return new ByteArrayInputStream(bytesRaw, bytesStart, bytesLength);
+            return new ByteArrayInputStream(bytes);
         }
 
-        /** Copy the byte range corresponding to the payload of the response,
-            Warning:  Copies the data, use getInputStream() for zero copy access */
         public byte[] getBodyBytes() {
-            return Arrays.copyOfRange(bytesRaw, bytesStart, bytesStart + bytesLength);
+            return bytes;
         }
 
         public Optional<Document> parseDocument() {
@@ -123,6 +135,9 @@ public sealed interface HttpFetchResult {
             return null;
         }
 
+        public int byteLength() {
+            return bytes.length;
+        }
     }
 
     /** This is a special case where the document was not fetched

--- a/code/processes/crawling-process/model/java/nu/marginalia/model/body/HttpFetchResult.java
+++ b/code/processes/crawling-process/model/java/nu/marginalia/model/body/HttpFetchResult.java
@@ -79,7 +79,7 @@ public sealed interface HttpFetchResult {
                                                 int statusCode,
                                                 Header[] headers,
                                                 String ipAddress,
-                                                InputStream stream) throws IOException {
+                                                InputStream rawStream) throws IOException {
             boolean isGzip = false;
 
             for (var header : headers) {
@@ -95,10 +95,13 @@ public sealed interface HttpFetchResult {
                 }
             }
 
-            if (isGzip) stream = new GZIPInputStream(stream);
-            byte[] bytes = stream.readNBytes(MAX_BODY_SIZE);
+            InputStream bytesStream = isGzip ? new GZIPInputStream(rawStream) : rawStream;
 
-            return new ResultOk(uri, statusCode, headers, ipAddress, bytes);
+            try (bytesStream) {
+                byte[] bytes = bytesStream.readNBytes(MAX_BODY_SIZE);
+
+                return new ResultOk(uri, statusCode, headers, ipAddress, bytes);
+            }
         }
 
         public boolean isOk() {

--- a/code/processes/crawling-process/test/nu/marginalia/crawl/fetcher/HttpFetcherImplFetchTest.java
+++ b/code/processes/crawling-process/test/nu/marginalia/crawl/fetcher/HttpFetcherImplFetchTest.java
@@ -375,8 +375,6 @@ class HttpFetcherImplFetchTest {
     private List<WarcRecord> getWarcRecords() throws IOException {
         List<WarcRecord> records = new ArrayList<>();
 
-        System.out.println(Files.readString(warcFile));
-
         try (var reader = new WarcReader(warcFile)) {
             WarcXResponseReference.register(reader);
             WarcXEntityRefused.register(reader);

--- a/code/processes/crawling-process/test/nu/marginalia/crawling/retreival/CrawlerMockFetcherTest.java
+++ b/code/processes/crawling-process/test/nu/marginalia/crawling/retreival/CrawlerMockFetcherTest.java
@@ -145,9 +145,7 @@ public class CrawlerMockFetcherTest {
                             200,
                             new Header[0],
                             "127.0.0.1",
-                            bodyBytes,
-                            0,
-                            bodyBytes.length
+                            bodyBytes
                     );
                 }
                 catch (URISyntaxException e) {

--- a/third-party/rssreader/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/third-party/rssreader/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -555,10 +555,12 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                     inputStream = new GZIPInputStream(inputStream);
                 }
 
-                inputStream = new BufferedInputStream(inputStream);
-                removeBadData(inputStream);
-                var itemIterator = new RssItemIterator(inputStream);
-                return AutoCloseStream.of(StreamUtil.asStream(itemIterator).onClose(itemIterator::close));
+                try (var bufferedStream = new BufferedInputStream(inputStream)) {
+                    removeBadData(bufferedStream);
+                    var itemIterator = new RssItemIterator(bufferedStream);
+                    return AutoCloseStream.of(StreamUtil.asStream(itemIterator).onClose(itemIterator::close));
+                }
+
             } catch (IOException e) {
                 throw new CompletionException(e);
             }


### PR DESCRIPTION
The crawler is unnecessarily disk-I/O intensive, as it's writing decompressed bytes to its intermediate WARC file, from which crawl data is recovered during a crash, and from which the final Slop data is constructed.

Technically WARCs are *supposed* to decompress data, but we'll skirt this requirement a bit for the sake of saving our SSDs from sustained >100 MB/s writes.

In testing, this drops disk writes from 130 MB/s to 90 MB/s.  Should have negligible performance impact since it just moves *when* we decompress the data.

## TODO:

- :x:  Decompress these entries in the for the Archival WARC exports (these should be compliant)
- [x]  Find why negative index exceptions are happening
