### PR TITLE
Handle empty branches in query graph

### DIFF
--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CompiledQueryParser.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CompiledQueryParser.java
@@ -68,38 +68,52 @@ public class CompiledQueryParser {
 
     private static class AndOrState {
         private List<CqExpression> andState = new ArrayList<>();
-        private List<CqExpression> orState = new ArrayList<>();
+        private final List<CqExpression> orState = new ArrayList<>();
 
-        /** Add a new item to the and-list */
         public void and(CqExpression e) {
             andState.add(e);
         }
 
-        /** Turn the and-list into an expression on the or-list, and then start a new and-list */
+        /** Close the current and-list into the or-list, then start a fresh and-list */
         public void or() {
-            closeAnd();
-
+            flushAnd();
             andState = new ArrayList<>();
         }
 
-        /** Turn the and-list into an And-expression in the or-list */
-        private void closeAnd() {
-            if (andState.size() == 1)
+        private void flushAnd() {
+            if (andState.isEmpty())
+                orState.add(CqExpression.Ignore.INSTANCE);
+            else if (andState.size() == 1)
                 orState.add(andState.getFirst());
-            else if (!andState.isEmpty())
+            else
                 orState.add(new CqExpression.And(andState));
         }
 
-        /** Finalize the current and-list, then turn the or-list into an Or-expression */
+        /** Finalize the current and-list, then turn the or-list into an Or-expression.
+         * An Ignore branch alongside a real branch expresses optionality (e.g.
+         * the trailing alternative in "( bar | )"). If every branch is empty
+         * (ignore or nested empty()) the whole group collapses to empty() to
+         * preserve behavior for inputs like "( | )" and "| ( | ) |".
+         */
         public CqExpression closeOr() {
-            closeAnd();
+            flushAnd();
 
-            if (orState.isEmpty())
+            List<CqExpression> parts = new ArrayList<>(orState.size());
+            boolean anyReal = false;
+            for (var e : orState) {
+                if (e instanceof CqExpression.Ignore) {
+                    parts.add(e);
+                } else if (!e.equals(CqExpression.empty())) {
+                    parts.add(e);
+                    anyReal = true;
+                }
+            }
+
+            if (!anyReal)
                 return CqExpression.empty();
-            if (orState.size() == 1)
-                return orState.getFirst();
-
-            return new CqExpression.Or(orState);
+            if (parts.size() == 1)
+                return parts.getFirst();
+            return new CqExpression.Or(parts);
         }
     }
 

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CqExpression.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CqExpression.java
@@ -127,4 +127,23 @@ public sealed interface CqExpression {
         }
     }
 
+    record Ignore() implements CqExpression {
+        public static final Ignore INSTANCE = new Ignore();
+
+        @Override
+        public Stream<Word> stream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public List<IntList> paths() {
+            return List.of(IntList.of());
+        }
+
+        @Override
+        public String toString() {
+            return "ignore";
+        }
+    }
+
 }

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CqExpression.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/compiled/CqExpression.java
@@ -5,10 +5,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntImmutableList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.stream.Stream;
 
 /** Expression in a parsed index service query
@@ -30,14 +27,17 @@ public sealed interface CqExpression {
         if (pathsRaw.isEmpty())
             return pathsRaw;
 
-        List<IntList> ret = new ArrayList<>(pathsRaw.size());
+        Set<IntList> ret = new LinkedHashSet<>(pathsRaw.size());
 
         for (IntList list: pathsRaw) {
+            // Remove pathological cases potentially introduced by empty branches
+            if (list.isEmpty()) continue;
+
             // sort, unique, and make immutable each the paths list
             ret.add(new IntImmutableList(new IntAVLTreeSet(list)));
         }
 
-        return Collections.unmodifiableList(ret);
+        return new ArrayList<>(ret);
     }
 
     record And(List<? extends CqExpression> parts) implements CqExpression {

--- a/code/functions/search-query/api/test/nu/marginalia/api/searchquery/model/compiled/CompiledQueryParserTest.java
+++ b/code/functions/search-query/api/test/nu/marginalia/api/searchquery/model/compiled/CompiledQueryParserTest.java
@@ -81,6 +81,14 @@ class CompiledQueryParserTest {
         assertEquals(w(q,"a"), q.root);
     }
 
+    @Test
+    public void testOptionalBranch() {
+        CompiledQuery<String> q = CompiledQueryParser.parse("foo ( bar | ) baz");
+        assertEquals(
+                and(w(q, "foo"), or(w(q, "bar"), ignore()), w(q, "baz")),
+                q.root);
+    }
+
     private CqExpression.Word w(CompiledQuery<String> query, String word) {
         return new CqExpression.Word(query.indices().filter(idx -> word.equals(query.at(idx))).findAny().orElseThrow());
     }
@@ -91,5 +99,9 @@ class CompiledQueryParserTest {
 
     private CqExpression or(CqExpression... parts) {
         return new CqExpression.Or(List.of(parts));
+    }
+
+    private CqExpression ignore() {
+        return CqExpression.Ignore.INSTANCE;
     }
 }

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryFactory.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryFactory.java
@@ -183,8 +183,9 @@ public class QueryFactory {
             queryBuilder.phraseConstraint(SearchPhraseConstraint.optional(coh));
         }
 
-        // add a pseudo-constraint for the full query
-        queryBuilder.phraseConstraint(SearchPhraseConstraint.full(expansion.fullPhraseConstraint()));
+        for (var cons : expansion.fullPhraseConstraints()) {
+            queryBuilder.phraseConstraint(SearchPhraseConstraint.full(cons));
+        }
         queryBuilder.compiledQuery(expansion.compiledQuery());
 
         if (!"NONE".equals(searchFilter.temporalBias())) {

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/QueryExpansion.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/QueryExpansion.java
@@ -134,8 +134,8 @@ public class QueryExpansion {
 
             switch (qw.word()) {
                 case "vs" -> {
-                    graph.addVariant(qw, "or");
-                    graph.addVariant(qw, "and");
+                    graph.addLink(graph.getPrevOriginal(qw).getFirst(),
+                            graph.getNextOriginal(qw).getFirst());
                 }
             }
         }

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/QueryExpansion.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/QueryExpansion.java
@@ -4,6 +4,7 @@ import ca.rmen.porterstemmer.PorterStemmer;
 import com.google.inject.Inject;
 import nu.marginalia.functions.searchquery.query_parser.model.QWord;
 import nu.marginalia.functions.searchquery.query_parser.model.QWordGraph;
+import nu.marginalia.functions.searchquery.query_parser.model.QWordGraphPathLister;
 import nu.marginalia.functions.searchquery.query_parser.model.QWordPathsRenderer;
 import nu.marginalia.language.NounVariants;
 import nu.marginalia.segmentation.NgramLexicon;
@@ -41,17 +42,9 @@ public class QueryExpansion {
             strategy.expand(graph);
         }
 
-        List<List<String>> optionalPhraseConstraints = createSegments(graph);
-
-        // also create a segmentation that is just the entire query
-        List<String> fullPhraseConstraint = new ArrayList<> ();
-        for (var qw : graph) {
-            fullPhraseConstraint.add(qw.word());
-        }
-
-        var compiled = QWordPathsRenderer.render(graph);
-
-        return new Expansion(compiled, optionalPhraseConstraints, fullPhraseConstraint);
+        return new Expansion(QWordPathsRenderer.render(graph),
+                createSegments(graph),
+                listFullConstraints(graph));
     }
 
     public List<ExpansionStrategy> getStrategies(String langIsoCode) {
@@ -136,6 +129,7 @@ public class QueryExpansion {
                 case "vs" -> {
                     graph.addLink(graph.getPrevOriginal(qw).getFirst(),
                             graph.getNextOriginal(qw).getFirst());
+                    graph.addVariant(qw, "and");
                 }
             }
         }
@@ -248,9 +242,42 @@ public class QueryExpansion {
         return new ArrayList<>(constraints);
     }
 
+    /** Enumerate full phrase constraints from all paths through the graph.
+     */
+    private static List<List<String>> listFullConstraints(QWordGraph graph) {
+        var paths = QWordGraphPathLister.listPaths(graph);
+        var reachability = graph.reachability();
+
+        Set<List<String>> result = new LinkedHashSet<>();
+
+        outer:
+        for (var path : paths) {
+            List<String> words = path.stream()
+                    .sorted(reachability.topologicalComparator())
+                    .map(QWord::word)
+                    .toList();
+
+            if (words.size() < 2)
+                continue;
+
+            // Exclude paths that contain ngrams, as these will never be meaningful for position matching
+            // since they lack position data
+            for (String word : words) {
+                if (word.contains("_"))
+                    continue outer;
+            }
+
+            result.add(words);
+        }
+
+        return new ArrayList<>(result);
+    }
+
     public interface ExpansionStrategy {
         void expand(QWordGraph graph);
     }
 
-    public record Expansion(String compiledQuery, List<List<String>> optionalPharseConstraints, List<String> fullPhraseConstraint) {}
+    public record Expansion(String compiledQuery,
+                            List<List<String>> optionalPharseConstraints,
+                            List<List<String>> fullPhraseConstraints) {}
 }

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/model/QWord.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/model/QWord.java
@@ -2,8 +2,6 @@ package nu.marginalia.functions.searchquery.query_parser.model;
 
 import ca.rmen.porterstemmer.PorterStemmer;
 
-import java.util.Objects;
-
 public record QWord(
         int ord,
         boolean variant,
@@ -51,21 +49,17 @@ public record QWord(
         return "q{" + word + "}";
     }
 
+    // Equality by ord keeps repeated surface words (e.g. "to be or not to be")
+    // distinct and lets beg/end sentinel instances compare equal across factory calls.
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        QWord qWord = (QWord) o;
-        return variant == qWord.variant && Objects.equals(word, qWord.word) && Objects.equals(stemmed, qWord.stemmed) && Objects.equals(isOriginal(), qWord.isOriginal());
+        if (!(o instanceof QWord qWord)) return false;
+        return ord == qWord.ord;
     }
 
     @Override
     public int hashCode() {
-        int result = Boolean.hashCode(variant);
-        result = 31 * result + Objects.hashCode(stemmed);
-        result = 31 * result + Objects.hashCode(word);
-        result = 31 * result + Objects.hashCode(isOriginal());
-        return result;
+        return Integer.hashCode(ord);
     }
 }

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/model/QWordPathsRenderer.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/query_parser/model/QWordPathsRenderer.java
@@ -41,7 +41,10 @@ public class QWordPathsRenderer {
      */
     String render(QWordGraph.ReachabilityData reachability) {
         if (paths.size() == 1) {
-            return paths.iterator().next().stream().map(QWord::word).collect(Collectors.joining(" "));
+            return paths.iterator().next().stream()
+                    .sorted(reachability.topologicalComparator())
+                    .map(QWord::word)
+                    .collect(Collectors.joining(" "));
         }
 
         // Find the commonality of words in the paths
@@ -65,25 +68,46 @@ public class QWordPathsRenderer {
         if (!commonToAll.isEmpty()) { // Case where one or more words are common to all paths
             commonToAll.sort(reachability.topologicalComparator());
 
-            for (var word : commonToAll) {
-                resultJoiner.add(word.word());
-            }
+            // Render the divergent portion (if any) and determine where it belongs
+            // topologically, so it can be interleaved between common words rather
+            // than always appended at the end.
+            String divergentRendered = "";
+            int divergentPos = Integer.MAX_VALUE;
 
-            // Deal portion of the paths that do not all share a common word
             if (!notCommonToAll.isEmpty()) {
-
                 List<QWordPath> nonOverlappingPortions = new ArrayList<>();
+                boolean hasEmptyProjection = false;
 
-                // Create a new path for each path that does not contain the common words we just printed
                 for (var path : paths) {
                     var np = path.project(notCommonToAll);
-                    if (np.isEmpty())
+                    if (np.isEmpty()) {
+                        // A path with no divergent words means the whole divergent
+                        // group is optional (e.g. introduced by a bridging edge).
+                        hasEmptyProjection = true;
                         continue;
+                    }
                     nonOverlappingPortions.add(np);
                 }
 
-                // Recurse into the non-overlapping portions
-                resultJoiner.add(render(nonOverlappingPortions, reachability));
+                if (!nonOverlappingPortions.isEmpty()) {
+                    String inner = render(nonOverlappingPortions, reachability);
+                    divergentRendered = hasEmptyProjection ? "( " + inner + " | )" : inner;
+                    divergentPos = notCommonToAll.stream()
+                            .mapToInt(reachability.sortOrder()::get)
+                            .min().orElse(Integer.MAX_VALUE);
+                }
+            }
+
+            boolean divergentEmitted = divergentRendered.isEmpty();
+            for (var word : commonToAll) {
+                if (!divergentEmitted && reachability.sortOrder().get(word) >= divergentPos) {
+                    resultJoiner.add(divergentRendered);
+                    divergentEmitted = true;
+                }
+                resultJoiner.add(word.word());
+            }
+            if (!divergentEmitted) {
+                resultJoiner.add(divergentRendered);
             }
         } else if (commonality.size() > 1) { // The case where no words are common to all paths
 

--- a/code/functions/search-query/test/nu/marginalia/functions/searchquery/query_parser/model/QWordGraphTest.java
+++ b/code/functions/search-query/test/nu/marginalia/functions/searchquery/query_parser/model/QWordGraphTest.java
@@ -1,5 +1,6 @@
 package nu.marginalia.functions.searchquery.query_parser.model;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,24 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class QWordGraphTest {
+
+    @Test
+    void testRepetition() {
+        QWordGraph graph = new QWordGraph("to", "be", "or", "not", "to", "be");
+        String compiled = graph.compileToQuery();
+        System.out.println(compiled);
+        Assertions.assertEquals("to be or not to be", compiled);
+    }
+
+    @Test
+    void testBriding() {
+        QWordGraph graph = new QWordGraph("first", "middle", "end");
+        // Bridge "first" directly to "end", making "middle" optional
+        graph.addLink(graph.node("first"), graph.node("end"));
+        String compiled = graph.compileToQuery();
+        System.out.println(compiled);
+        Assertions.assertEquals("first ( middle | ) end", compiled);
+    }
 
     @Test
     void forwardReachability() {
@@ -65,7 +84,7 @@ class QWordGraphTest {
         QWordGraph graph = new QWordGraph("q", "b", "c");
         graph.addVariant(graph.node("b"), "d");
 
-        assertEquals("q c ( b | d )", graph.compileToQuery());
+        assertEquals("q ( b | d ) c", graph.compileToQuery());
     }
 
     @Test
@@ -86,7 +105,7 @@ class QWordGraphTest {
         //   \- d -/
         QWordGraph graph = new QWordGraph("q", "b", "c");
         graph.addVariant(graph.node("q"), "d");
-        assertEquals("b c ( q | d )", graph.compileToQuery());
+        assertEquals("( q | d ) b c", graph.compileToQuery());
     }
 
     @Test
@@ -111,6 +130,6 @@ class QWordGraphTest {
         QWordGraph graph = new QWordGraph("q", "b", "c");
         graph.addVariant(graph.node("c"), "d");
         graph.addVariant(graph.node("b"), "e");
-        assertEquals("q ( c ( b | e ) | d ( b | e ) )", graph.compileToQuery());
+        assertEquals("q ( b ( c | d ) | e ( c | d ) )", graph.compileToQuery());
     }
 }

--- a/code/functions/search-query/test/nu/marginalia/query/svc/QueryFactoryTest.java
+++ b/code/functions/search-query/test/nu/marginalia/query/svc/QueryFactoryTest.java
@@ -212,6 +212,7 @@ public class QueryFactoryTest {
     @Test
     public void testExpansion() {
         var subquery = parseAndGetQuery("elden ring mechanical keyboard slackware linux duke nukem 3d").getTerms();
+
         System.out.println(subquery.getCompiledQuery());
     }
 
@@ -267,11 +268,13 @@ public class QueryFactoryTest {
     public void testExpansion10() {
         var subquery = parseAndGetQuery("when was captain james cook born");
         System.out.println(subquery);
+
     }
 
     @Test
     public void testExpansion11() {
         var subquery = parseAndGetQuery("traceroute vs tracepath");
+        System.out.println(subquery);
     }
 
     @Test

--- a/code/index/java/nu/marginalia/index/model/PhraseConstraintGroupList.java
+++ b/code/index/java/nu/marginalia/index/model/PhraseConstraintGroupList.java
@@ -23,24 +23,27 @@ public class PhraseConstraintGroupList {
     /** A list of groups representing segments of the query */
     private final List<PhraseConstraintGroup> optionalGroups = new ArrayList<>();
 
-    /** A group representing all terms in the query, segmentation be damned */
-    private final PhraseConstraintGroup fullGroup;
+    /** Groups representing the full query in all its variant orderings.
+     *  The first entry is the primary (original word sequence); the rest
+     *  are alternative paths introduced by query expansion (e.g. bridging). */
+    private final List<PhraseConstraintGroup> fullGroups;
 
     public PhraseConstraintGroupList(
-            PhraseConstraintGroup fullGroup,
+            List<PhraseConstraintGroup> fullGroups,
             List<PhraseConstraintGroup> mandatoryGroups,
             List<PhraseConstraintGroup> optionalGroups) {
         this.mandatoryGroups.addAll(mandatoryGroups);
         this.optionalGroups.addAll(optionalGroups);
-        this.fullGroup = fullGroup;
+        this.fullGroups = List.copyOf(fullGroups);
     }
 
     public List<PhraseConstraintGroup> getOptionalGroups() {
         return Collections.unmodifiableList(optionalGroups);
     }
 
-    public PhraseConstraintGroup getFullGroup() {
-        return fullGroup;
+    /** Returns all full groups, including alternatives from variant paths. */
+    public List<PhraseConstraintGroup> getFullGroups() {
+        return fullGroups;
     }
 
     public boolean testMandatory(CodedSequence[] positions) {

--- a/code/index/java/nu/marginalia/index/model/SearchContext.java
+++ b/code/index/java/nu/marginalia/index/model/SearchContext.java
@@ -256,7 +256,7 @@ public class SearchContext {
             constraintsFull.add(new PhraseConstraintGroupList.PhraseConstraintGroup(keywordHasher, queryTerms.getTermsRequireList(), termIdsAll));
         }
 
-        this.phraseConstraints = new PhraseConstraintGroupList(constraintsFull.getFirst(), constraintsMandatory, constraintsOptional);
+        this.phraseConstraints = new PhraseConstraintGroupList(constraintsFull, constraintsMandatory, constraintsOptional);
     }
 
     public int termFreqDocCount() {

--- a/code/index/java/nu/marginalia/index/results/IndexResultRankingService.java
+++ b/code/index/java/nu/marginalia/index/results/IndexResultRankingService.java
@@ -2,22 +2,16 @@ package nu.marginalia.index.results;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import gnu.trove.list.TLongList;
-import gnu.trove.list.array.TLongArrayList;
-import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import nu.marginalia.api.searchquery.*;
 import nu.marginalia.api.searchquery.model.compiled.CompiledQuery;
 import nu.marginalia.api.searchquery.model.compiled.CompiledQueryLong;
-import nu.marginalia.api.searchquery.model.compiled.CqDataLong;
 import nu.marginalia.api.searchquery.model.compiled.aggregate.CompiledQueryAggregates;
 import nu.marginalia.api.searchquery.model.query.QueryStrategy;
 import nu.marginalia.api.searchquery.model.results.SearchResultItem;
 import nu.marginalia.api.searchquery.model.results.debug.DebugRankingFactors;
 import nu.marginalia.index.CombinedIndexReader;
-import nu.marginalia.index.ResultPriorityQueue;
 import nu.marginalia.index.ScratchIntListPool;
 import nu.marginalia.index.StatefulIndex;
 import nu.marginalia.index.forward.spans.DocumentSpans;
@@ -25,7 +19,6 @@ import nu.marginalia.index.model.*;
 import nu.marginalia.index.searchset.connectivity.DomainSetConnectivity;
 import nu.marginalia.language.sentence.tag.HtmlTag;
 import nu.marginalia.linkdb.docs.DocumentDbReader;
-import nu.marginalia.linkdb.model.DocdbUrlDetail;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.id.UrlIdCodec;
@@ -37,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.sql.SQLException;
 import java.util.*;
 
 import static nu.marginalia.api.searchquery.model.compiled.aggregate.CompiledQueryAggregates.booleanAggregate;
@@ -265,13 +257,15 @@ public class IndexResultRankingService {
     private long calculatePositionsMask(ScratchIntListPool intListPool, IntList[] positions, PhraseConstraintGroupList phraseConstraints) {
 
         long result = 0;
-        int bit = 0;
 
-        IntIterator intersection = phraseConstraints.getFullGroup().findIntersections(intListPool, positions, 64).intIterator();
+        for (var fullGroup : phraseConstraints.getFullGroups()) {
+            int bit = 0;
+            IntIterator intersection = fullGroup.findIntersections(intListPool, positions, 64).intIterator();
 
-        while (intersection.hasNext() && bit < 64) {
-            bit = (int) (Math.sqrt(intersection.nextInt()));
-            result |= 1L << bit;
+            while (intersection.hasNext() && bit < 64) {
+                bit = (int) (Math.sqrt(intersection.nextInt()));
+                result |= 1L << bit;
+            }
         }
 
         return result;
@@ -371,13 +365,12 @@ public class IndexResultRankingService {
         float proximitiyFac = 0;
 
         if (positions.length > 2) {
-            var fullGroup = constraintGroups.getFullGroup();
-
-            int minDist = fullGroup.minDistance(positions);
-            if (minDist > 0 && minDist < Integer.MAX_VALUE) {
-                if (minDist < fullGroup.size + 8) {
-                    // If min-dist is sufficiently small, we give a tapering reward to the document
-                    proximitiyFac = 2.0f / (0.1f + (float) Math.sqrt(minDist));
+            for (var fullGroup : constraintGroups.getFullGroups()) {
+                int minDist = fullGroup.minDistance(positions);
+                if (minDist > 0 && minDist < Integer.MAX_VALUE) {
+                    if (minDist < fullGroup.size + 8) {
+                        proximitiyFac = Math.max(proximitiyFac, 2.0f / (0.1f + (float) Math.sqrt(minDist)));
+                    }
                 }
             }
         }
@@ -456,60 +449,29 @@ public class IndexResultRankingService {
         public VerbatimMatches(ScratchIntListPool intListPool, IntList[] positions, PhraseConstraintGroupList constraints, DocumentSpans spans) {
             matches = new BitSet(HtmlTag.includedTags.length);
 
-            PhraseConstraintGroupList.PhraseConstraintGroup fullGroup = constraints.getFullGroup();
-            IntList fullGroupIntersections = fullGroup.findIntersections(intListPool, positions);
+            float bestScore = 0.f;
+            BitSet tmpMatches = new BitSet(HtmlTag.includedTags.length);
+            int fullGroupSize = 1;
 
-            if (fullGroup.size == 1) {
-                var titleSpan = spans.getSpan(HtmlTag.TITLE);
-                if (titleSpan.length() == fullGroup.size
-                        && titleSpan.containsRange(fullGroupIntersections, fullGroup.size))
-                {
-                    score += 4; // If the title is a single word and the same as the query, we give it a verbatim bonus
+            for (var fullGroup: constraints.getFullGroups()) {
+                tmpMatches.clear();
+
+                float score;
+
+                if (fullGroup.size == 1) {
+                    score = calculateSingleTermFullGroupScore(fullGroup, tmpMatches, intListPool, positions, spans);
                 }
-
-                int exactMatches = spans
-                        .getSpan(HtmlTag.EXTERNAL_LINKTEXT)
-                        .countRangeMatchesExact(fullGroupIntersections, fullGroup.size);
-
-                int partialMatches = spans
-                            .getSpan(HtmlTag.EXTERNAL_LINKTEXT)
-                            .countRangeMatches(fullGroupIntersections, fullGroup.size);
-
-                partialMatches -= exactMatches;
-
-                score += 1.5 * exactMatches + 0.5 * partialMatches;
-
-                return;
-            }
-
-
-            /**
-             *  FULL GROUP MATCHING
-             */
-            if (!fullGroupIntersections.isEmpty()) {
-                int totalFullCnts = 0;
-
-                // Capture full query matches
-                for (var tag : HtmlTag.includedTags) {
-                    int cnts = spans.getSpan(tag).countRangeMatches(fullGroupIntersections, fullGroup.size);
-                    if (cnts > 0) {
-                        matches.set(tag.ordinal());
-                        score += (float) (weights_full[tag.ordinal()] * fullGroup.size * (1 + Math.log(1 + Math.pow(cnts, attenuation[tag.ordinal()]))));
-                        totalFullCnts += cnts;
-                    }
+                else {
+                    score = calculateMultiTermFullGroupScore(fullGroup, tmpMatches, intListPool, positions, spans);
                 }
+                if (score > bestScore) {
+                    matches.clear();
+                    matches.or(tmpMatches);
 
-                // Handle matches that span multiple tags; treat them as BODY matches
-                if (totalFullCnts != fullGroupIntersections.size()) {
-                    int mixedCnts = fullGroupIntersections.size() - totalFullCnts;
-                    score += (float) (weights_full[HtmlTag.BODY.ordinal()] * fullGroup.size * (1 + Math.log(1 + Math.pow(mixedCnts, attenuation[HtmlTag.BODY.ordinal()]))));
-                }
+                    this.score = score;
+                    bestScore = score;
 
-                // Bonus when the full query aligns with the beginning or end of a title
-                int titleBoundaryMatches = spans.getSpan(HtmlTag.TITLE)
-                        .countRangeMatchesAtBoundary(fullGroupIntersections, fullGroup.size);
-                if (titleBoundaryMatches > 0) {
-                    score += 1.5f * titleBoundaryMatches;
+                    fullGroupSize = fullGroup.size;
                 }
             }
 
@@ -519,28 +481,119 @@ public class IndexResultRankingService {
 
             // For optional groups, we scale the score by the size of the group relative to the full group
             for (PhraseConstraintGroupList.PhraseConstraintGroup optionalGroup : constraints.getOptionalGroups()) {
-                float sizeScalingFactor = (float) Math.sqrt(optionalGroup.size / (float) fullGroup.size);
+                score += calculateOptionalGroupScore(optionalGroup, intListPool, positions, spans, fullGroupSize);
+            }
+        }
 
-                IntList intersections = optionalGroup.findIntersections(intListPool, positions);
+        private float calculateMultiTermFullGroupScore(PhraseConstraintGroupList.PhraseConstraintGroup fullGroup,
+                                                       BitSet matches,
+                                                       ScratchIntListPool intListPool,
+                                                       IntList[] positions, DocumentSpans spans) {
+            IntList fullGroupIntersections = fullGroup.findIntersections(intListPool, positions);
 
-                if (intersections.isEmpty())
-                    continue;
+            if (fullGroupIntersections.isEmpty())
+                return 0.f;
 
-                int totalCnts = 0;
-                for (var tag : HtmlTag.includedTags) {
-                    int cnts =  spans.getSpan(tag).countRangeMatches(intersections, optionalGroup.size);
-                    if (cnts == 0) continue;
+            float score = 0.f;
+            int totalFullCnts = 0;
 
-                    score += (float) (weights_partial[tag.ordinal()] * optionalGroup.size * sizeScalingFactor * (1 + Math.log(1 + Math.pow(cnts, attenuation[tag.ordinal()]))));
-                    totalCnts += cnts;
-                }
-
-                // Handle matches that span multiple tags; treat them as BODY matches
-                if (totalCnts != intersections.size()) {
-                    int mixedCnts = intersections.size() - totalCnts;
-                    score += (float) (weights_partial[HtmlTag.BODY.ordinal()] * optionalGroup.size * sizeScalingFactor * (1 + Math.log(1 + Math.pow(mixedCnts, attenuation[HtmlTag.BODY.ordinal()]))));
+            // Capture full query matches
+            for (var tag : HtmlTag.includedTags) {
+                int cnts = spans.getSpan(tag).countRangeMatches(fullGroupIntersections, fullGroup.size);
+                if (cnts > 0) {
+                    matches.set(tag.ordinal());
+                    score += (float) (weights_full[tag.ordinal()] * fullGroup.size
+                            * (1 + Math.log(1 + Math.pow(cnts, attenuation[tag.ordinal()]))));
+                    totalFullCnts += cnts;
                 }
             }
+
+            // Handle matches that span multiple tags; treat them as BODY matches
+            if (totalFullCnts != fullGroupIntersections.size()) {
+                int mixedCnts = fullGroupIntersections.size() - totalFullCnts;
+                score += (float) (weights_full[HtmlTag.BODY.ordinal()] * fullGroup.size
+                        * (1 + Math.log(1 + Math.pow(mixedCnts, attenuation[HtmlTag.BODY.ordinal()]))));
+            }
+
+            // Bonus when the full query aligns with the beginning or end of a title
+            int titleBoundaryMatches = spans.getSpan(HtmlTag.TITLE)
+                    .countRangeMatchesAtBoundary(fullGroupIntersections, fullGroup.size);
+            if (titleBoundaryMatches > 0) {
+                score += 1.5f * titleBoundaryMatches;
+            }
+
+            return score;
+        }
+
+        private float calculateSingleTermFullGroupScore(PhraseConstraintGroupList.PhraseConstraintGroup fullGroup,
+                                                        BitSet matches,
+                                                        ScratchIntListPool intListPool,
+                                                        IntList[] positions,
+                                                        DocumentSpans spans)
+        {
+            IntList fullGroupIntersections = fullGroup.findIntersections(intListPool, positions);
+
+            if (fullGroupIntersections.isEmpty())
+                return 0.f;
+
+            float score = 0.f;
+
+            var titleSpan = spans.getSpan(HtmlTag.TITLE);
+            if (titleSpan.length() == fullGroup.size
+                    && titleSpan.containsRange(fullGroupIntersections, fullGroup.size))
+            {
+                score += 4; // If the title is a single word and the same as the query, we give it a verbatim bonus
+            }
+
+            int exactMatches = spans
+                    .getSpan(HtmlTag.EXTERNAL_LINKTEXT)
+                    .countRangeMatchesExact(fullGroupIntersections, fullGroup.size);
+
+            int partialMatches = spans
+                    .getSpan(HtmlTag.EXTERNAL_LINKTEXT)
+                    .countRangeMatches(fullGroupIntersections, fullGroup.size);
+
+            partialMatches -= exactMatches;
+
+            score += 1.5 * exactMatches + 0.5 * partialMatches;
+
+            return score;
+        }
+
+
+        private float calculateOptionalGroupScore(PhraseConstraintGroupList.PhraseConstraintGroup optionalGroup,
+                                                  ScratchIntListPool intListPool,
+                                                  IntList[] positions,
+                                                  DocumentSpans spans,
+                                                  int fullGroupSize)
+        {
+            float sizeScalingFactor = (float) Math.sqrt(optionalGroup.size / (float) fullGroupSize);
+
+            IntList intersections = optionalGroup.findIntersections(intListPool, positions);
+
+            if (intersections.isEmpty())
+                return 0.f;
+
+            float score = 0.f;
+
+            int totalCnts = 0;
+            for (var tag : HtmlTag.includedTags) {
+                int cnts =  spans.getSpan(tag).countRangeMatches(intersections, optionalGroup.size);
+                if (cnts == 0) continue;
+
+                score += (float) (weights_partial[tag.ordinal()] * optionalGroup.size * sizeScalingFactor
+                                    * (1 + Math.log(1 + Math.pow(cnts, attenuation[tag.ordinal()]))));
+                totalCnts += cnts;
+            }
+
+            // Handle matches that span multiple tags; treat them as BODY matches
+            if (totalCnts != intersections.size()) {
+                int mixedCnts = intersections.size() - totalCnts;
+                score += (float) (weights_partial[HtmlTag.BODY.ordinal()] * optionalGroup.size * sizeScalingFactor
+                                    * (1 + Math.log(1 + Math.pow(mixedCnts, attenuation[HtmlTag.BODY.ordinal()]))));
+            }
+
+            return score;
         }
 
         public boolean get(HtmlTag tag) {


### PR DESCRIPTION
This is intended to fix issue #283 . 

We add support empty branches in the query graph.  We also update the query parser and index to support multiple full constraint groups, to get better results from variant queries.

## Todo
 
- [x] Investigate how the index lookup logic deals with these new branches
- [x] Investigate how the index ranking logic deals with these new branches
- [x] Support multiple full constraint groups
- [x] Requires coordinated QS and Index restart: Wait for an appropriate time to merge