### PR TITLE
Fix WARC archival of gzip-encoded HTTP responses

### DIFF
--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.zip.GZIPInputStream;
 
 /** Input buffer for temporary storage of a HTTP response
  *  This may be in-memory or on-disk, at the discretion of
@@ -67,13 +68,28 @@ public abstract class WarcInputBuffer implements AutoCloseable {
                 return new ErrorBuffer();
             }
 
+            Header[] headers = response.getHeaders();
+            boolean isGzip = false;
+            for (var header : headers) {
+                if ("Content-Encoding".equalsIgnoreCase(header.getName())
+                        && "gzip".equalsIgnoreCase(header.getValue())) {
+                    isGzip = true;
+                    break;
+                }
+            }
+
+            InputStream bodyStream = isGzip ? new GZIPInputStream(is) : is;
+            Header[] storedHeaders = isGzip
+                    ? Arrays.stream(headers).filter(h -> !"Content-Encoding".equalsIgnoreCase(h.getName())).toArray(Header[]::new)
+                    : headers;
+
             if (length > 0 && length < 8192) {
-                return new MemoryBuffer(response.getHeaders(), request, timeLimit, is, (int) length);
+                return new MemoryBuffer(storedHeaders, request, timeLimit, bodyStream, (int) length);
             }
             else {
                 // handles both the negative length case (e.g. HTTP 1.0)
                 // and the known length case
-                return new FileBuffer(response.getHeaders(), request, timeLimit, is, tempDir);
+                return new FileBuffer(storedHeaders, request, timeLimit, bodyStream, tempDir);
             }
         }
         finally {

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcInputBuffer.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.zip.GZIPInputStream;
 
 /** Input buffer for temporary storage of a HTTP response
  *  This may be in-memory or on-disk, at the discretion of
@@ -68,28 +67,13 @@ public abstract class WarcInputBuffer implements AutoCloseable {
                 return new ErrorBuffer();
             }
 
-            Header[] headers = response.getHeaders();
-            boolean isGzip = false;
-            for (var header : headers) {
-                if ("Content-Encoding".equalsIgnoreCase(header.getName())
-                        && "gzip".equalsIgnoreCase(header.getValue())) {
-                    isGzip = true;
-                    break;
-                }
-            }
-
-            InputStream bodyStream = isGzip ? new GZIPInputStream(is) : is;
-            Header[] storedHeaders = isGzip
-                    ? Arrays.stream(headers).filter(h -> !"Content-Encoding".equalsIgnoreCase(h.getName())).toArray(Header[]::new)
-                    : headers;
-
             if (length > 0 && length < 8192) {
-                return new MemoryBuffer(storedHeaders, request, timeLimit, bodyStream, (int) length);
+                return new MemoryBuffer(response.getHeaders(), request, timeLimit, is, (int) length);
             }
             else {
                 // handles both the negative length case (e.g. HTTP 1.0)
                 // and the known length case
-                return new FileBuffer(storedHeaders, request, timeLimit, bodyStream, tempDir);
+                return new FileBuffer(response.getHeaders(), request, timeLimit, is, tempDir);
             }
         }
         finally {

--- a/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcProtocolReconstructor.java
+++ b/code/processes/crawling-process/java/nu/marginalia/crawl/fetcher/warc/WarcProtocolReconstructor.java
@@ -175,6 +175,10 @@ public class WarcProtocolReconstructor {
             if (headerCapitalized.equals("Transfer-Encoding"))
                 continue;
 
+            // Omit Content-Encoding as the body is transparently decoded
+            if (headerCapitalized.equals("Content-Encoding"))
+                continue;
+
             // Since we're transparently decoding gzip, we need to update the Content-Length header
             // to reflect the actual size of the response body. We'll do this at the end.
             if (headerCapitalized.equals("Content-Length"))

--- a/code/processes/crawling-process/test/nu/marginalia/crawl/retreival/fetcher/WarcRecorderFakeServerTest.java
+++ b/code/processes/crawling-process/test/nu/marginalia/crawl/retreival/fetcher/WarcRecorderFakeServerTest.java
@@ -11,8 +11,10 @@ import org.netpreserve.jwarc.WarcReader;
 import org.netpreserve.jwarc.WarcRequest;
 import org.netpreserve.jwarc.WarcResponse;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -20,6 +22,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 
 @Tag("slow")
 class WarcRecorderFakeServerTest {
@@ -37,6 +40,23 @@ class WarcRecorderFakeServerTest {
             try (var os = exchange.getResponseBody()) {
                 os.write("<html><body>hello</body></html>".getBytes());
                 os.flush();
+            }
+            exchange.close();
+        });
+
+        // This endpoint serves a gzip-compressed response
+        server.createContext("/gzip", exchange -> {
+            byte[] html = "<html><body>hello gzip</body></html>".getBytes(StandardCharsets.UTF_8);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+                gzos.write(html);
+            }
+            byte[] compressed = baos.toByteArray();
+            exchange.getResponseHeaders().add("Content-Type", "text/html");
+            exchange.getResponseHeaders().add("Content-Encoding", "gzip");
+            exchange.sendResponseHeaders(200, compressed.length);
+            try (var os = exchange.getResponseBody()) {
+                os.write(compressed);
             }
             exchange.close();
         });
@@ -157,6 +177,28 @@ class WarcRecorderFakeServerTest {
         // so we expect the request to take 1s and change before it times out.
 
         Assertions.assertTrue(Duration.between(start, end).toMillis() < 3000);
+    }
+
+    @Test
+    public void fetchGzip() throws Exception {
+        HttpGet request = new HttpGet("http://localhost:14510/gzip");
+        request.addHeader("User-agent", "test.marginalia.nu");
+        client.fetch(httpClient, new DomainCookies(), request);
+
+        try (var warcReader = new WarcReader(fileNameWarc)) {
+            for (var record : warcReader) {
+                if (record instanceof WarcResponse rsp) {
+                    var http = rsp.http();
+                    Assertions.assertTrue(http.headers().first("Content-Encoding").isEmpty(),
+                            "WARC response must not retain Content-Encoding");
+                    try (var body = http.body()) {
+                        String bodyStr = new String(body.stream().readAllBytes(), StandardCharsets.UTF_8);
+                        Assertions.assertTrue(bodyStr.contains("hello gzip"),
+                                "WARC response body must be decompressed");
+                    }
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Servers send gzip responses with Content-Encoding headers. We were storing these directly in WARC without decompressing. Now we decompress the stream and strip the header before storage. Added a test.