### PR TITLE
(converter) Improve error handling and retry logic for DOM sample fetching

### DIFF
--- a/code/common/config/java/nu/marginalia/nodecfg/NodeConfigurationService.java
+++ b/code/common/config/java/nu/marginalia/nodecfg/NodeConfigurationService.java
@@ -123,4 +123,8 @@ public class NodeConfigurationService {
 
         }
     }
+
+    public boolean hasNodeProfile(NodeProfile profile) {
+        return getAll().stream().anyMatch(c -> c.profile() == profile);
+    }
 }

--- a/code/index/live-capture/api/java/nu/marginalia/api/domsample/DomSampleClient.java
+++ b/code/index/live-capture/api/java/nu/marginalia/api/domsample/DomSampleClient.java
@@ -5,6 +5,7 @@ import com.google.inject.Singleton;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import nu.marginalia.nodecfg.NodeConfigurationService;
+import nu.marginalia.nodecfg.model.NodeProfile;
 import nu.marginalia.service.client.GrpcChannelPoolFactory;
 import nu.marginalia.service.client.GrpcSingleNodeChannelPool;
 import nu.marginalia.service.discovery.property.ServiceKey;
@@ -24,13 +25,19 @@ import java.util.concurrent.ExecutorService;
 public class DomSampleClient {
     private final GrpcSingleNodeChannelPool<DomSampleApiGrpc.DomSampleApiBlockingStub> channelPool;
     private static final Logger logger = LoggerFactory.getLogger(DomSampleClient.class);
+    private final NodeConfigurationService nodeConfigurationService;
 
     @Inject
-    public DomSampleClient(GrpcChannelPoolFactory factory, NodeConfigurationService service) {
+    public DomSampleClient(GrpcChannelPoolFactory factory, NodeConfigurationService nodeConfigurationService) {
+        this.nodeConfigurationService = nodeConfigurationService;
 
         // The client is only interested in the primary node
         var key = ServiceKey.forGrpcApi(DomSampleApiGrpc.class, ServicePartition.any());
         this.channelPool = factory.createSingle(key, DomSampleApiGrpc::newBlockingStub);
+    }
+
+    public boolean isSupported() {
+        return nodeConfigurationService.hasNodeProfile(NodeProfile.REALTIME);
     }
 
     public Optional<RpcDomainSample> getSample(String domainName) {

--- a/code/index/live-capture/api/java/nu/marginalia/api/domsample/DomSampleClient.java
+++ b/code/index/live-capture/api/java/nu/marginalia/api/domsample/DomSampleClient.java
@@ -92,6 +92,11 @@ public class DomSampleClient {
                 .run(RpcDomainName.newBuilder().setDomainName(domainName).build());
     }
 
+    public RpcDomainSample getSampleOrThrow(String domainName) {
+        return channelPool.call(DomSampleApiGrpc.DomSampleApiBlockingStub::getSample)
+                .run(RpcDomainName.newBuilder().setDomainName(domainName).build());
+    }
+
     public List<RpcDomainSample> getAllSamples(String domainName) {
         try {
             Iterator<RpcDomainSample> val = channelPool.call(DomSampleApiGrpc.DomSampleApiBlockingStub::getAllSamples)

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
@@ -26,6 +26,7 @@ import nu.marginalia.model.crawl.UrlIndexingState;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.model.crawldata.CrawledDomain;
 import nu.marginalia.model.crawldata.CrawlerDomainStatus;
+import nu.marginalia.process.control.ProcessEventLog;
 import nu.marginalia.service.client.ServiceNotAvailableException;
 import nu.marginalia.util.ProcessingIterator;
 import org.apache.commons.lang3.StringUtils;
@@ -36,7 +37,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 public class DomainProcessor {
@@ -45,10 +49,14 @@ public class DomainProcessor {
     private final AnchorTagsSource anchorTagsSource;
     private final GeoIpDictionary geoIpDictionary;
     private final DomSampleClient domSampleClient;
+    private final ProcessEventLog eventLog;
     private final DomSampleClassifier domSampleClassifier;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final boolean hasDomSamples;
+
+    private final AtomicReference<Instant> domSampleDataDegradedLastNag = new AtomicReference<>();
+    private final AtomicBoolean domSampleDegraded = new AtomicBoolean(false);
 
     @Inject
     public DomainProcessor(DocumentProcessor documentProcessor,
@@ -56,12 +64,14 @@ public class DomainProcessor {
                            AnchorTagsSourceFactory anchorTagsSourceFactory,
                            DomSampleClient domSampleClient,
                            GeoIpDictionary geoIpDictionary,
+                           ProcessEventLog eventLog,
                            DomSampleClassifier domSampleClassifier) throws SQLException, InterruptedException {
         this.documentProcessor = documentProcessor;
         this.siteWords = siteWords;
         this.anchorTagsSource = anchorTagsSourceFactory.create();
         this.geoIpDictionary = geoIpDictionary;
         this.domSampleClient = domSampleClient;
+        this.eventLog = eventLog;
         this.domSampleClassifier = domSampleClassifier;
 
         geoIpDictionary.waitReady();
@@ -97,13 +107,19 @@ public class DomainProcessor {
 
         for (;;) {
             try {
-                return domSampleClassifier.classifySample(
+                var ret = domSampleClassifier.classifySample(
                         domSampleClient.getSampleOrThrow(domainName)
                 );
+
+                logOnDomSampleRecovered();
+
+                return ret;
             }
             catch (StatusRuntimeException sre) {
 
                 if (sre.getStatus().getCode() == Status.NOT_FOUND.getCode()) {
+                    logOnDomSampleRecovered();
+
                     break;
                 }
 
@@ -117,10 +133,34 @@ public class DomainProcessor {
                 throw new InterruptedException();
             }
 
+            logOnDomSampleStuck();
+
             Thread.sleep(Duration.ofSeconds(10));
         }
 
         return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
+    }
+
+    private void logOnDomSampleStuck() {
+        domSampleDegraded.set(true);
+
+        Instant now = Instant.now();
+        Instant val = domSampleDataDegradedLastNag.get();
+
+        if (val == null || val.isBefore(now.minus(Duration.ofMinutes(30)))) {
+            if (domSampleDataDegradedLastNag.compareAndSet(val, now)) {
+                eventLog.logEvent("CONVERTER-STUCK",
+                        "Converter waiting for DOM sample availability.  REALTIME node may be degraded.");
+            }
+        }
+    }
+
+    private void logOnDomSampleRecovered() {
+        if (domSampleDegraded.compareAndSet(true, false)) {
+            domSampleDataDegradedLastNag.set(null);
+            eventLog.logEvent("CONVERTER-RECOVERED",
+                    "Converter is no longer waiting for DOM sample availability.");
+        }
     }
 
     @Nullable

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
@@ -26,6 +26,7 @@ import nu.marginalia.model.crawl.UrlIndexingState;
 import nu.marginalia.model.crawldata.CrawledDocument;
 import nu.marginalia.model.crawldata.CrawledDomain;
 import nu.marginalia.model.crawldata.CrawlerDomainStatus;
+import nu.marginalia.service.client.ServiceNotAvailableException;
 import nu.marginalia.util.ProcessingIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -36,9 +37,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 public class DomainProcessor {
@@ -48,7 +46,6 @@ public class DomainProcessor {
     private final GeoIpDictionary geoIpDictionary;
     private final DomSampleClient domSampleClient;
     private final DomSampleClassifier domSampleClassifier;
-    private final ExecutorService domSampleExecutor = Executors.newCachedThreadPool();
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final boolean hasDomSamples;
@@ -68,7 +65,8 @@ public class DomainProcessor {
         this.domSampleClassifier = domSampleClassifier;
 
         geoIpDictionary.waitReady();
-        hasDomSamples = !Boolean.getBoolean("converter.ignoreDomSampleData") && domSampleClient.waitReady(Duration.ofSeconds(15));
+
+        hasDomSamples = Boolean.getBoolean("converter.useDomSampleData");
     }
 
     public SimpleProcessing simpleProcessing(SerializableCrawlDataStream dataStream, int sizeHint, Collection<String> extraKeywords) {
@@ -92,24 +90,37 @@ public class DomainProcessor {
     }
 
     /** Fetch and process the DOM sample and extract classifications */
-    private Set<DomSampleClassification> getDomainClassifications(String domainName) throws ExecutionException, InterruptedException {
+    private Set<DomSampleClassification> getDomainClassifications(String domainName) throws InterruptedException {
         if (!hasDomSamples) {
             return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
         }
 
-        return domSampleClient
-                .getSampleAsync(domainName, domSampleExecutor)
-                .thenApply(domSampleClassifier::classifySample)
-                .handle((a,b) -> {
-                    if (b != null) {
-                        var cause = b.getCause();
-                        if (!(cause instanceof StatusRuntimeException sre && sre.getStatus() != Status.NOT_FOUND)) {
-                            logger.warn("Exception when fetching sample data", b);
-                        }
-                        return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
-                    }
-                    return a;
-                }).get();
+        for (;;) {
+            try {
+                return domSampleClassifier.classifySample(
+                        domSampleClient.getSampleOrThrow(domainName)
+                );
+            }
+            catch (StatusRuntimeException sre) {
+
+                if (sre.getStatus().getCode() == Status.NOT_FOUND.getCode()) {
+                    break;
+                }
+
+                logger.warn("Failed to fetch DOM sample for {} -- {}, retrying in 10 seconds" , domainName, sre.getStatus().getDescription());
+            }
+            catch (ServiceNotAvailableException snae) {
+                logger.warn("Failed to fetch DOM sample for {}, waiting for DomSampleService availability" , domainName);
+            }
+
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+
+            Thread.sleep(Duration.ofSeconds(10));
+        }
+
+        return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
     }
 
     @Nullable

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
@@ -76,7 +76,8 @@ public class DomainProcessor {
 
         geoIpDictionary.waitReady();
 
-        hasDomSamples = Boolean.getBoolean("converter.useDomSampleData");
+        hasDomSamples = !Boolean.getBoolean("converter.ignoreDomSampleData")
+                && domSampleClient.isSupported();
     }
 
     public SimpleProcessing simpleProcessing(SerializableCrawlDataStream dataStream, int sizeHint, Collection<String> extraKeywords) {

--- a/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
+++ b/code/processes/converting-process/java/nu/marginalia/converting/processor/DomainProcessor.java
@@ -100,70 +100,6 @@ public class DomainProcessor {
         }
     }
 
-    /** Fetch and process the DOM sample and extract classifications */
-    private Set<DomSampleClassification> getDomainClassifications(String domainName) throws InterruptedException {
-        if (!hasDomSamples) {
-            return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
-        }
-
-        for (;;) {
-            try {
-                var ret = domSampleClassifier.classifySample(
-                        domSampleClient.getSampleOrThrow(domainName)
-                );
-
-                logOnDomSampleRecovered();
-
-                return ret;
-            }
-            catch (StatusRuntimeException sre) {
-
-                if (sre.getStatus().getCode() == Status.NOT_FOUND.getCode()) {
-                    logOnDomSampleRecovered();
-
-                    break;
-                }
-
-                logger.warn("Failed to fetch DOM sample for {} -- {}, retrying in 10 seconds" , domainName, sre.getStatus().getDescription());
-            }
-            catch (ServiceNotAvailableException snae) {
-                logger.warn("Failed to fetch DOM sample for {}, waiting for DomSampleService availability" , domainName);
-            }
-
-            if (Thread.interrupted()) {
-                throw new InterruptedException();
-            }
-
-            logOnDomSampleStuck();
-
-            Thread.sleep(Duration.ofSeconds(10));
-        }
-
-        return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
-    }
-
-    private void logOnDomSampleStuck() {
-        domSampleDegraded.set(true);
-
-        Instant now = Instant.now();
-        Instant val = domSampleDataDegradedLastNag.get();
-
-        if (val == null || val.isBefore(now.minus(Duration.ofMinutes(30)))) {
-            if (domSampleDataDegradedLastNag.compareAndSet(val, now)) {
-                eventLog.logEvent("CONVERTER-STUCK",
-                        "Converter waiting for DOM sample availability.  REALTIME node may be degraded.");
-            }
-        }
-    }
-
-    private void logOnDomSampleRecovered() {
-        if (domSampleDegraded.compareAndSet(true, false)) {
-            domSampleDataDegradedLastNag.set(null);
-            eventLog.logEvent("CONVERTER-RECOVERED",
-                    "Converter is no longer waiting for DOM sample availability.");
-        }
-    }
-
     @Nullable
     public ProcessedDomain fullProcessing(SerializableCrawlDataStream dataStream) {
         try {
@@ -465,5 +401,70 @@ public class DomainProcessor {
         };
     }
 
+
+
+    /** Fetch and process the DOM sample and extract classifications */
+    private Set<DomSampleClassification> getDomainClassifications(String domainName) throws InterruptedException {
+        if (!hasDomSamples) {
+            return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
+        }
+
+        for (;;) {
+            try {
+                var ret = domSampleClassifier.classifySample(
+                        domSampleClient.getSampleOrThrow(domainName)
+                );
+
+                logOnDomSampleRecovered();
+
+                return ret;
+            }
+            catch (StatusRuntimeException sre) {
+
+                if (sre.getStatus().getCode() == Status.NOT_FOUND.getCode()) {
+                    logOnDomSampleRecovered();
+
+                    break;
+                }
+
+                logger.warn("Failed to fetch DOM sample for {} -- {}, retrying in 10 seconds" , domainName, sre.getStatus().getDescription());
+            }
+            catch (ServiceNotAvailableException snae) {
+                logger.warn("Failed to fetch DOM sample for {}, waiting for DomSampleService availability" , domainName);
+            }
+
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+
+            logOnDomSampleStuck();
+
+            Thread.sleep(Duration.ofSeconds(10));
+        }
+
+        return EnumSet.of(DomSampleClassification.UNCLASSIFIED);
+    }
+
+    private void logOnDomSampleStuck() {
+        domSampleDegraded.set(true);
+
+        Instant now = Instant.now();
+        Instant val = domSampleDataDegradedLastNag.get();
+
+        if (val == null || val.isBefore(now.minus(Duration.ofMinutes(30)))) {
+            if (domSampleDataDegradedLastNag.compareAndSet(val, now)) {
+                eventLog.logEvent("CONVERTER-STUCK",
+                        "Converter waiting for DOM sample availability.  REALTIME node may be degraded.");
+            }
+        }
+    }
+
+    private void logOnDomSampleRecovered() {
+        if (domSampleDegraded.compareAndSet(true, false)) {
+            domSampleDataDegradedLastNag.set(null);
+            eventLog.logEvent("CONVERTER-RECOVERED",
+                    "Converter is no longer waiting for DOM sample availability.");
+        }
+    }
 
 }


### PR DESCRIPTION
Previously, the REALTIME node having issues would cause the converter to skip applying DOM sample data to domains until it returned to a healthy state.  This would cause some search results to miss their classification, and rank higher than they should.

We now wait until it's available, as long as necessary.  To help alert the operator if this is a long term issue, an event log entry is created.  

Additionally, a pointless `getAsync(executor).join()`-pattern was removed.   

## Todo

- [x] Add REALTIME node check to `hasDomSamples` 
