### PR TITLE
(index) Add early domain limit to ResultPriorityQueue

### DIFF
--- a/code/index/java/nu/marginalia/index/IndexQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexQueryExecution.java
@@ -105,7 +105,7 @@ public class IndexQueryExecution {
         this.rankingService = rankingService;
         this.rankingContext = rankingContext;
 
-        resultHeap = new ResultPriorityQueue(rankingContext.limitTotal * 2);
+        resultHeap = new ResultPriorityQueue(rankingContext.limitTotal, rankingContext.limitByDomain);
 
         budget = rankingContext.budget;
         limitByDomain = rankingContext.limitByDomain;
@@ -159,18 +159,12 @@ public class IndexQueryExecution {
         List<RankableDocument> resultsList = new ArrayList<>(resultHeap.size());
         LongList idsList = new LongArrayList(limitTotal);
 
-        Int2IntOpenHashMap domainCount = new Int2IntOpenHashMap(limitByDomain);
-
         for (RankableDocument item : resultHeap) {
             if (resultsList.size() >= limitTotal) {
                 break;
             }
 
             int domainId = item.domainId();
-
-            if (domainCount.addTo(domainId, 1) >= limitByDomain) {
-                continue;
-            }
 
             resultsList.add(item);
             item.resultsFromDomain = resultHeap.numResultsFromDomain(domainId);
@@ -412,7 +406,7 @@ public class IndexQueryExecution {
 
         // per-thread instances
         private final ScratchIntListPool pool = new ScratchIntListPool(64);
-        private final ResultPriorityQueue localResults = new ResultPriorityQueue(rankingContext.limitTotal);
+        private final ResultPriorityQueue localResults = new ResultPriorityQueue(rankingContext.limitTotal, rankingContext.limitByDomain);
 
         private final Lock indexLock = currentIndex.useLock();
 

--- a/code/index/java/nu/marginalia/index/ResultPriorityQueue.java
+++ b/code/index/java/nu/marginalia/index/ResultPriorityQueue.java
@@ -1,8 +1,6 @@
 package nu.marginalia.index;
 
-import com.google.common.collect.MinMaxPriorityQueue;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import nu.marginalia.index.model.RankableDocument;
 import nu.marginalia.model.id.UrlIdCodec;
 import org.jetbrains.annotations.NotNull;
@@ -12,44 +10,115 @@ import java.util.*;
 /** A priority queue for search results. This class is not thread-safe.
  */
 public class ResultPriorityQueue implements Iterable<RankableDocument> {
-    private final MinMaxPriorityQueue<RankableDocument> queue;
-    private final Int2IntOpenHashMap resultsPerDomain = new Int2IntOpenHashMap(10_000);
+    private final TreeSet<RankableDocument> queue;
+
+    /** The number of results seen from each domain (including rejects) */
+    private final Int2IntOpenHashMap resultsPerDomainSeen;
+
+    /** The number of results currently held from each domain */
+    private final Int2IntOpenHashMap resultsPerDomainHeld;
 
     private int itemsProcessed = 0;
+    private final int limit;
+    private final int domainLimit;
 
-    public ResultPriorityQueue(int limit) {
-        this.queue = MinMaxPriorityQueue.<RankableDocument>orderedBy(Comparator.naturalOrder()).maximumSize(limit).create();
+    public ResultPriorityQueue(int limit, int domainLimit) {
+        this.queue = new TreeSet<>(Comparator.naturalOrder());
+
+        this.resultsPerDomainHeld = new Int2IntOpenHashMap(limit);
+        this.resultsPerDomainHeld.defaultReturnValue(0);
+
+        this.resultsPerDomainSeen = new Int2IntOpenHashMap(2_500);
+        this.resultsPerDomainSeen.defaultReturnValue(0);
+
+        this.limit = limit;
+        this.domainLimit = domainLimit;
     }
 
     public @NotNull Iterator<RankableDocument> iterator() {
-        ArrayList<RankableDocument> results = new ArrayList<>(queue);
-        results.sort(Comparator.naturalOrder());
-        return results.iterator();
+        return queue.iterator();
     }
 
     public void addAll(ResultPriorityQueue otherQueue) {
-        queue.addAll(otherQueue.queue);
-        otherQueue.resultsPerDomain.int2IntEntrySet().fastForEach(entry -> {
-            resultsPerDomain.addTo(entry.getIntKey(), entry.getIntValue());
+        for (var doc : otherQueue) {
+            // Add with no statistics
+            add(doc, false);
+        }
+
+        // Merge the statistics
+        otherQueue.resultsPerDomainSeen.int2IntEntrySet().fastForEach(entry -> {
+            resultsPerDomainSeen.addTo(entry.getIntKey(), entry.getIntValue());
         });
         itemsProcessed += otherQueue.itemsProcessed;
     }
 
     public boolean add(@NotNull RankableDocument document) {
+        return add(document, true);
+    }
+
+    private boolean add(@NotNull RankableDocument document, boolean updateStats) {
         if (document.item == null)
             return false;
 
         int domainId = UrlIdCodec.getDomainId(document.combinedDocumentId);
 
-        itemsProcessed++;
+        if (updateStats) {
+            resultsPerDomainSeen.addTo(domainId, 1);
+            itemsProcessed++;
+        }
+
+        // Short circuit if we're already at the limit and this item is worse than the last one
+        if (queue.size() >= limit) {
+            var last = queue.last();
+            if (last.item.compareTo(document.item) <= 0) {
+                return false;
+            }
+        }
+
         queue.add(document);
-        resultsPerDomain.addTo(domainId, 1);
+
+        resultsPerDomainHeld.addTo(domainId, 1);
+
+        pruneDomain(domainId);
+        removeExcessItems();
 
         return true;
     }
 
+
+    private void removeExcessItems() {
+
+        while (queue.size() > limit) {
+            var item = queue.pollLast();
+
+            if (1 == resultsPerDomainHeld.addTo(item.domainId(), -1)) {
+                resultsPerDomainHeld.remove(item.domainId());
+            }
+        }
+
+    }
+
+    private void pruneDomain(int domainId) {
+        int heldCount = resultsPerDomainHeld.get(domainId);
+
+        if (heldCount < domainLimit) {
+            return;
+        }
+
+        for (var iter = queue.reversed().iterator(); iter.hasNext() && heldCount > domainLimit; ) {
+            var item = iter.next();
+
+            if (item.domainId() != domainId)
+                continue;
+
+            iter.remove();
+            resultsPerDomainHeld.addTo(domainId, -1);
+            heldCount--;
+        }
+    }
+
     public int numResultsFromDomain(int domainId) {
-        return resultsPerDomain.get(domainId);
+        return resultsPerDomainSeen.get(domainId);
     }
 
     public int size() {

--- a/code/index/test/nu/marginalia/index/ResultPriorityQueueTest.java
+++ b/code/index/test/nu/marginalia/index/ResultPriorityQueueTest.java
@@ -1,0 +1,137 @@
+package nu.marginalia.index;
+
+import nu.marginalia.api.searchquery.model.results.SearchResultItem;
+import nu.marginalia.index.model.RankableDocument;
+import nu.marginalia.model.id.UrlIdCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResultPriorityQueueTest {
+
+    @Test
+    public void testAddWithinLimit() {
+        var q = new ResultPriorityQueue(5, 5);
+
+        assertTrue(q.add(doc(1, 1, 1.0)));
+        assertTrue(q.add(doc(2, 1, 2.0)));
+        assertTrue(q.add(doc(3, 1, 3.0)));
+
+        assertEquals(3, q.size());
+        assertEquals(List.of(1.0, 2.0, 3.0), scoresInOrder(q));
+    }
+
+    @Test
+    public void testKeepBest() {
+        var q = new ResultPriorityQueue(3, 5);
+
+        q.add(doc(1, 1, 9.0));
+        q.add(doc(2, 1, 8.0));
+        q.add(doc(3, 1, 7.0));
+        q.add(doc(4, 1, 2.0));
+        q.add(doc(5, 1, 1.0));
+        q.add(doc(6, 1, 5.0));
+
+        assertEquals(3, q.size());
+        assertEquals(List.of(1.0, 2.0, 5.0), scoresInOrder(q));
+    }
+
+    @Test
+    public void testReplaceWhenFull() {
+        var q = new ResultPriorityQueue(3, 5);
+        q.add(doc(1, 1, 5.0));
+        q.add(doc(2, 1, 6.0));
+        q.add(doc(3, 1, 7.0));
+
+        // Should be accepted
+        assertTrue(q.add(doc(4, 1, 4.0)));
+        assertEquals(3, q.size());
+        assertEquals(List.of(4.0, 5.0, 6.0), scoresInOrder(q));
+    }
+
+    @Test
+    public void testRejectWhenFull() {
+        var q = new ResultPriorityQueue(3, 5);
+        q.add(doc(1, 1, 1.0));
+        q.add(doc(2, 1, 2.0));
+        q.add(doc(3, 1, 3.0));
+
+        // Should be rejected early
+        assertFalse(q.add(doc(4, 1, 9.0)));
+        assertEquals(3, q.size());
+        assertEquals(List.of(1.0, 2.0, 3.0), scoresInOrder(q));
+    }
+
+    @Test
+    public void testNumResultsFromDomain() {
+        // Adding includes items that get pruned or rejected at the domain cap.
+        var q = new ResultPriorityQueue(100, 2);
+
+        for (int i = 1; i <= 5; i++) {
+            q.add(doc(7, i, i));
+        }
+
+        assertEquals(2, q.size());
+        assertEquals(5, q.numResultsFromDomain(7));
+    }
+
+    @Test
+    public void testMergeStats() {
+        var a = new ResultPriorityQueue(10, 5);
+        a.add(doc(1, 1, 1.0));
+        a.add(doc(1, 2, 3.0));
+
+        var b = new ResultPriorityQueue(10, 5);
+        b.add(doc(2, 1, 2.0));
+        b.add(doc(2, 2, 4.0));
+
+        a.addAll(b);
+
+        assertEquals(4, a.size());
+        assertEquals(List.of(1.0, 2.0, 3.0, 4.0), scoresInOrder(a));
+        assertEquals(2, a.numResultsFromDomain(1));
+        assertEquals(2, a.numResultsFromDomain(2));
+        assertEquals(4, a.getItemsProcessed());
+    }
+
+    @Test
+    public void testItemsProcessed() {
+        var a = new ResultPriorityQueue(2, 5);
+
+        a.add(doc(1, 1, 1.0));
+        a.add(doc(1, 2, 2.0));
+        a.add(doc(1, 3, 3.0));
+        a.add(doc(1, 4, 4.0));
+        assertEquals(4, a.getItemsProcessed());
+
+        var b = new ResultPriorityQueue(2, 5);
+        b.add(doc(2, 1, 1.5));
+        b.add(doc(2, 2, 2.5));
+        b.add(doc(2, 3, 3.5));
+        assertEquals(3, b.getItemsProcessed());
+
+        a.addAll(b);
+
+        assertEquals(7, a.getItemsProcessed());
+    }
+
+    public static RankableDocument doc(int domainId, int ordinal, double score) {
+        long combinedId = UrlIdCodec.encodeId(domainId, ordinal);
+        RankableDocument d = new RankableDocument(combinedId);
+        d.item = new SearchResultItem(combinedId, 0L, 0, score, 0L);
+        return d;
+    }
+
+    public static List<Double> scoresInOrder(ResultPriorityQueue q) {
+        List<Double> out = new ArrayList<>();
+        for (RankableDocument d : q) {
+            out.add(d.item.getScore());
+        }
+        return out;
+    }
+}


### PR DESCRIPTION
The ResultPriorityQueue has had some issue with results being rejected by results that would later be removed via domainLimit constraints.  We bake this into the priority queue and reject bad results as we go.  This should improve search result quality, giving more relevant results.

## TODO

- [x] Test in prod on an index node