### PR TITLE
Optimize naive PorterStemmer implementation

### DIFF
--- a/third-party/porterstemmer/build.gradle
+++ b/third-party/porterstemmer/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id "me.champeau.jmh" version "0.7.3"
 }
 
 java {
@@ -9,6 +10,21 @@ java {
 }
 
 dependencies {
+    testImplementation libs.bundles.junit
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+jmh {
+    jvmArgs = [ "--enable-preview" ]
+    profilers = [ "gc" ]
+}
+tasks.withType(me.champeau.jmh.WithJavaToolchain).configureEach {
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(rootProject.ext.jvmVersion))
+    })
+}
+tasks.withType(me.champeau.jmh.JmhBytecodeGeneratorTask).configureEach {
+    jvmArgs = ["--enable-preview"]
 }
 
 test {

--- a/third-party/porterstemmer/src/jmh/java/ca/rmen/porterstemmer/StemmerBench.java
+++ b/third-party/porterstemmer/src/jmh/java/ca/rmen/porterstemmer/StemmerBench.java
@@ -1,0 +1,48 @@
+package ca.rmen.porterstemmer;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class StemmerBench {
+
+    public String wordlist = "/usr/share/dict/words";
+
+    private List<String> words;
+    private final PorterStemmer current = new PorterStemmer();
+    private final PorterStemmerOriginal original = new PorterStemmerOriginal();
+
+    @Setup(Level.Trial)
+    public void loadWords() throws IOException {
+        words = Files.readAllLines(Path.of(wordlist));
+    }
+
+    @Benchmark
+    public int stemCurrent() {
+        // Sum the stem lengths so the JIT can't dead-code the call.
+        int acc = 0;
+        for (int i = 0, n = words.size(); i < n; i++) {
+            acc += current.stemWord(words.get(i)).length();
+        }
+        return acc;
+    }
+
+    @Benchmark
+    public int stemOriginal() {
+        int acc = 0;
+        for (int i = 0, n = words.size(); i < n; i++) {
+            acc += original.stemWord(words.get(i)).length();
+        }
+        return acc;
+    }
+}

--- a/third-party/porterstemmer/src/main/java/ca/rmen/porterstemmer/PorterStemmer.java
+++ b/third-party/porterstemmer/src/main/java/ca/rmen/porterstemmer/PorterStemmer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016 Carmen Alvarez + modifications from Viktor Lofgren
  *
  * This file is part of Porter Stemmer.
  *
@@ -25,10 +25,97 @@ import java.util.Locale;
  * This is a simple implementation of the Porter stemming algorithm, defined here:
  * <a href="http://tartarus.org/martin/PorterStemmer/def.txt">http://tartarus.org/martin/PorterStemmer/def.txt</a>
  * <p>
- * This implementation has not been tuned for high performance on large amounts of text. It is
- * a simple (naive perhaps) implementation of the rules.
+ * This is an optimized version that uses a StringBuilder to go fast.
  */
 public class PorterStemmer {
+
+    private static final String[] STEP2_SUFFIXES = {
+            "ational",
+            "tional",
+            "enci",
+            "anci",
+            "izer",
+            "bli", // the published algorithm specifies abli instead of bli.
+            "alli",
+            "entli",
+            "eli",
+            "ousli",
+            "ization",
+            "ation",
+            "ator",
+            "alism",
+            "iveness",
+            "fulness",
+            "ousness",
+            "aliti",
+            "iviti",
+            "biliti",
+            "logi", // the published algorithm doesn't contain this
+    };
+    private static final String[] STEP2_REPLACEMENTS = {
+            "ate",
+            "tion",
+            "ence",
+            "ance",
+            "ize",
+            "ble", // the published algorithm specifies able instead of ble
+            "al",
+            "ent",
+            "e",
+            "ous",
+            "ize",
+            "ate",
+            "ate",
+            "al",
+            "ive",
+            "ful",
+            "ous",
+            "al",
+            "ive",
+            "ble",
+            "log" // the published algorithm doesn't contain this
+    };
+
+    private static final String[] STEP3_SUFFIXES = {
+            "icate",
+            "ative",
+            "alize",
+            "iciti",
+            "ical",
+            "ful",
+            "ness",
+    };
+    private static final String[] STEP3_REPLACEMENTS = {
+            "ic",
+            "",
+            "al",
+            "ic",
+            "ic",
+            "",
+            "",
+    };
+
+    private static final String[] STEP4_SUFFIXES = {
+            "al",
+            "ance",
+            "ence",
+            "er",
+            "ic",
+            "able",
+            "ible",
+            "ant",
+            "ement",
+            "ment",
+            "ent",
+            "ion",
+            "ou",
+            "ism",
+            "ate",
+            "iti",
+            "ous",
+            "ive",
+            "ize",
+    };
 
     /**
      * @param word the word to stem
@@ -37,281 +124,188 @@ public class PorterStemmer {
     public String stemWord(String word) {
         String stem = word.toLowerCase(Locale.getDefault());
         if (stem.length() < 3) return stem;
-        stem = stemStep1a(stem);
-        stem = stemStep1b(stem);
-        stem = stemStep1c(stem);
-        stem = stemStep2(stem);
-        stem = stemStep3(stem);
-        stem = stemStep4(stem);
-        stem = stemStep5a(stem);
-        stem = stemStep5b(stem);
-        return stem;
+        StringBuilder sb = new StringBuilder(stem);
+        stemStep1a(sb);
+        stemStep1b(sb);
+        stemStep1c(sb);
+        stemStep2(sb);
+        stemStep3(sb);
+        stemStep4(sb);
+        stemStep5a(sb);
+        stemStep5b(sb);
+        return sb.toString();
     }
 
-    String stemStep1a(String input) {
+    void stemStep1a(StringBuilder sb) {
         // SSES -> SS
-        if (input.endsWith("sses")) {
-            return input.substring(0, input.length() - 2);
+        if (endsWith(sb, "sses")) {
+            sb.setLength(sb.length() - 2);
+            return;
         }
         // IES  -> I
-        if (input.endsWith("ies")) {
-            return input.substring(0, input.length() - 2);
+        if (endsWith(sb, "ies")) {
+            sb.setLength(sb.length() - 2);
+            return;
         }
         // SS   -> SS
-        if (input.endsWith("ss")) {
-            return input;
+        if (endsWith(sb, "ss")) {
+            return;
         }
         // S    ->
-        if (input.endsWith("s")) {
-            return input.substring(0, input.length() - 1);
+        if (endsWith(sb, "s")) {
+            sb.setLength(sb.length() - 1);
         }
-        return input;
     }
 
-    String stemStep1b(String input) {
+    void stemStep1b(StringBuilder sb) {
         // (m>0) EED -> EE
-        if (input.endsWith("eed")) {
-            String stem = input.substring(0, input.length() - 1);
-            String letterTypes = getLetterTypes(stem);
-            int m = getM(letterTypes);
-            if (m > 0) return stem;
-            return input;
+        if (endsWith(sb, "eed")) {
+            int stemLen = sb.length() - 1;
+            int m = getM(sb, stemLen);
+            if (m > 0) sb.setLength(stemLen);
+            return;
         }
         // (*v*) ED  ->
-        if (input.endsWith("ed")) {
-            String stem = input.substring(0, input.length() - 2);
-            String letterTypes = getLetterTypes(stem);
-            if (letterTypes.contains("v")) {
-                return step1b2(stem);
+        if (endsWith(sb, "ed")) {
+            int stemLen = sb.length() - 2;
+            if (containsVowel(sb, stemLen)) {
+                sb.setLength(stemLen);
+                step1b2(sb);
             }
-            return input;
+            return;
         }
         // (*v*) ING ->
-        if (input.endsWith("ing")) {
-            String stem = input.substring(0, input.length() - 3);
-            String letterTypes = getLetterTypes(stem);
-            if (letterTypes.contains("v")) {
-                return step1b2(stem);
+        if (endsWith(sb, "ing")) {
+            int stemLen = sb.length() - 3;
+            if (containsVowel(sb, stemLen)) {
+                sb.setLength(stemLen);
+                step1b2(sb);
             }
-            return input;
         }
-        return input;
     }
 
-    private String step1b2(String input) {
+    private void step1b2(StringBuilder sb) {
         // AT -> ATE
-        if (input.endsWith("at")) {
-            return input + "e";
+        if (endsWith(sb, "at")) {
+            sb.append('e');
         }
         // BL -> BLE
-        else if (input.endsWith("bl")) {
-            return input + "e";
+        else if (endsWith(sb, "bl")) {
+            sb.append('e');
         }
         // IZ -> IZE
-        else if (input.endsWith("iz")) {
-            return input + "e";
+        else if (endsWith(sb, "iz")) {
+            sb.append('e');
         } else {
             // (*d and not (*L or *S or *Z))
             // -> single letter
-            char lastDoubleConsonant = getLastDoubleConsonant(input);
+            char lastDoubleConsonant = getLastDoubleConsonant(sb);
             if (lastDoubleConsonant != 0 &&
                     lastDoubleConsonant != 'l'
                     && lastDoubleConsonant != 's'
                     && lastDoubleConsonant != 'z') {
-                return input.substring(0, input.length() - 1);
+                sb.setLength(sb.length() - 1);
             }
             // (m=1 and *o) -> E
             else {
-                String letterTypes = getLetterTypes(input);
-                int m = getM(letterTypes);
-                if (m == 1 && isStarO(input)) {
-                    return input + "e";
+                int m = getM(sb, sb.length());
+                if (m == 1 && isStarO(sb, sb.length())) {
+                    sb.append('e');
                 }
 
             }
         }
-        return input;
     }
 
-    String stemStep1c(String input) {
-        if (input.endsWith("y")) {
-            String stem = input.substring(0, input.length() - 1);
-            String letterTypes = getLetterTypes(stem);
-            if (letterTypes.contains("v")) return stem + "i";
+    void stemStep1c(StringBuilder sb) {
+        if (endsWith(sb, "y")) {
+            int stemLen = sb.length() - 1;
+            if (containsVowel(sb, stemLen)) sb.setCharAt(stemLen, 'i');
         }
-        return input;
     }
 
-    String stemStep2(String input) {
-        String[] s1 = new String[]{
-                "ational",
-                "tional",
-                "enci",
-                "anci",
-                "izer",
-                "bli", // the published algorithm specifies abli instead of bli.
-                "alli",
-                "entli",
-                "eli",
-                "ousli",
-                "ization",
-                "ation",
-                "ator",
-                "alism",
-                "iveness",
-                "fulness",
-                "ousness",
-                "aliti",
-                "iviti",
-                "biliti",
-                "logi", // the published algorithm doesn't contain this
-        };
-        String[] s2 = new String[]{
-                "ate",
-                "tion",
-                "ence",
-                "ance",
-                "ize",
-                "ble", // the published algorithm specifies able instead of ble
-                "al",
-                "ent",
-                "e",
-                "ous",
-                "ize",
-                "ate",
-                "ate",
-                "al",
-                "ive",
-                "ful",
-                "ous",
-                "al",
-                "ive",
-                "ble",
-                "log" // the published algorithm doesn't contain this
-        };
+    void stemStep2(StringBuilder sb) {
         // (m>0) ATIONAL ->  ATE
         // (m>0) TIONAL  ->  TION
-        for (int i = 0; i < s1.length; i++) {
-            if (input.endsWith(s1[i])) {
-                String stem = input.substring(0, input.length() - s1[i].length());
-                String letterTypes = getLetterTypes(stem);
-                int m = getM(letterTypes);
-                if (m > 0) return stem + s2[i];
-                return input;
+        for (int i = 0; i < STEP2_SUFFIXES.length; i++) {
+            if (endsWith(sb, STEP2_SUFFIXES[i])) {
+                int stemLen = sb.length() - STEP2_SUFFIXES[i].length();
+                int m = getM(sb, stemLen);
+                if (m > 0) {
+                    sb.setLength(stemLen);
+                    sb.append(STEP2_REPLACEMENTS[i]);
+                }
+                return;
             }
         }
-        return input;
     }
 
-    String stemStep3(String input) {
-        String[] s1 = new String[]{
-                "icate",
-                "ative",
-                "alize",
-                "iciti",
-                "ical",
-                "ful",
-                "ness",
-        };
-        String[] s2 = new String[]{
-                "ic",
-                "",
-                "al",
-                "ic",
-                "ic",
-                "",
-                "",
-        };
+    void stemStep3(StringBuilder sb) {
         // (m>0) ICATE ->  IC
         // (m>0) ATIVE ->
-        for (int i = 0; i < s1.length; i++) {
-            if (input.endsWith(s1[i])) {
-                String stem = input.substring(0, input.length() - s1[i].length());
-                String letterTypes = getLetterTypes(stem);
-                int m = getM(letterTypes);
-                if (m > 0) return stem + s2[i];
-                return input;
+        for (int i = 0; i < STEP3_SUFFIXES.length; i++) {
+            if (endsWith(sb, STEP3_SUFFIXES[i])) {
+                int stemLen = sb.length() - STEP3_SUFFIXES[i].length();
+                int m = getM(sb, stemLen);
+                if (m > 0) {
+                    sb.setLength(stemLen);
+                    sb.append(STEP3_REPLACEMENTS[i]);
+                }
+                return;
             }
         }
-        return input;
 
     }
 
-    String stemStep4(String input) {
-        String[] suffixes = new String[]{
-                "al",
-                "ance",
-                "ence",
-                "er",
-                "ic",
-                "able",
-                "ible",
-                "ant",
-                "ement",
-                "ment",
-                "ent",
-                "ion",
-                "ou",
-                "ism",
-                "ate",
-                "iti",
-                "ous",
-                "ive",
-                "ize",
-        };
+    void stemStep4(StringBuilder sb) {
         // (m>1) AL    ->
         // (m>1) ANCE  ->
-        for(String suffix : suffixes) {
-            if (input.endsWith(suffix)) {
-                String stem = input.substring(0, input.length() - suffix.length());
-                String letterTypes = getLetterTypes(stem);
-                int m = getM(letterTypes);
+        for(String suffix : STEP4_SUFFIXES) {
+            if (endsWith(sb, suffix)) {
+                int stemLen = sb.length() - suffix.length();
+                int m = getM(sb, stemLen);
                 if (m > 1) {
                     if (suffix.equals("ion")) {
-                        if (stem.charAt(stem.length() - 1) == 's' || stem.charAt(stem.length() - 1) == 't') {
-                            return stem;
+                        if (sb.charAt(stemLen - 1) == 's' || sb.charAt(stemLen - 1) == 't') {
+                            sb.setLength(stemLen);
                         }
                     } else {
-                        return stem;
+                        sb.setLength(stemLen);
                     }
                 }
-                return input;
+                return;
             }
         }
-        return input;
     }
 
-    String stemStep5a(String input) {
-        if (input.endsWith("e")) {
-            String stem = input.substring(0, input.length() - 1);
-            String letterTypes = getLetterTypes(stem);
-            int m = getM(letterTypes);
+    void stemStep5a(StringBuilder sb) {
+        if (endsWith(sb, "e")) {
+            int stemLen = sb.length() - 1;
+            int m = getM(sb, stemLen);
             // (m>1) E     ->
             if (m > 1) {
-                return stem;
+                sb.setLength(stemLen);
+                return;
             }
             // (m=1 and not *o) E ->
-            if (m == 1 && !isStarO(stem)) {
-                return stem;
+            if (m == 1 && !isStarO(sb, stemLen)) {
+                sb.setLength(stemLen);
             }
         }
-        return input;
     }
 
-    String stemStep5b(String input) {
+    void stemStep5b(StringBuilder sb) {
         // (m > 1 and *d and *L) -> single letter
-        String letterTypes = getLetterTypes(input);
-        int m = getM(letterTypes);
-        if (m > 1 && input.endsWith("ll")) {
-            return input.substring(0, input.length() - 1);
+        int m = getM(sb, sb.length());
+        if (m > 1 && endsWith(sb, "ll")) {
+            sb.setLength(sb.length() - 1);
         }
-        return input;
     }
 
-    private char getLastDoubleConsonant(String input) {
-        if (input.length() < 2) return 0;
-        char lastLetter = input.charAt(input.length() - 1);
-        char penultimateLetter = input.charAt(input.length() - 2);
+    private char getLastDoubleConsonant(StringBuilder sb) {
+        if (sb.length() < 2) return 0;
+        char lastLetter = sb.charAt(sb.length() - 1);
+        char penultimateLetter = sb.charAt(sb.length() - 2);
         if (lastLetter == penultimateLetter && getLetterType((char) 0, lastLetter) == 'c') {
             return lastLetter;
         }
@@ -320,37 +314,56 @@ public class PorterStemmer {
 
     // *o  - the stem ends cvc, where the second c is not W, X or Y (e.g.
     //                                                              -WIL, -HOP)
-    private boolean isStarO(String input) {
-        if (input.length() < 3) return false;
+    private boolean isStarO(StringBuilder sb, int len) {
+        if (len < 3) return false;
 
-        char lastLetter = input.charAt(input.length() - 1);
+        char lastLetter = sb.charAt(len - 1);
         if (lastLetter == 'w' || lastLetter == 'x' || lastLetter == 'y') return false;
 
-        char secondToLastLetter = input.charAt(input.length() - 2);
-        char thirdToLastLetter = input.charAt(input.length() - 3);
-        char fourthToLastLetter = input.length() == 3 ? 0 : input.charAt(input.length() - 4);
+        char secondToLastLetter = sb.charAt(len - 2);
+        char thirdToLastLetter = sb.charAt(len - 3);
+        char fourthToLastLetter = len == 3 ? 0 : sb.charAt(len - 4);
         return getLetterType(secondToLastLetter, lastLetter) == 'c'
                 && getLetterType(thirdToLastLetter, secondToLastLetter) == 'v'
                 && getLetterType(fourthToLastLetter, thirdToLastLetter) == 'c';
     }
 
-    String getLetterTypes(String input) {
-        StringBuilder letterTypes = new StringBuilder(input.length());
-        for (int i = 0; i < input.length(); i++) {
-            char letter = input.charAt(i);
-            char previousLetter = i == 0 ? 0 : input.charAt(i - 1);
-            char letterType = getLetterType(previousLetter, letter);
-            if (letterTypes.length() == 0 || letterTypes.charAt(letterTypes.length() - 1) != letterType) {
-                letterTypes.append(letterType);
-            }
+    // m is the number of v -> c transitions in the per-character c/v sequence
+    // over sb[0..len). Equivalent to the original "collapse same-type runs,
+    // count VC pairs" formulation, without materialising the collapsed string.
+    int getM(StringBuilder sb, int len) {
+        int m = 0;
+        char prevLetter = 0;
+        char prevType = 0;
+        for (int i = 0; i < len; i++) {
+            char c = sb.charAt(i);
+            char type = getLetterType(prevLetter, c);
+            if (prevType == 'v' && type == 'c') m++;
+            prevLetter = c;
+            prevType = type;
         }
-        return letterTypes.toString();
+        return m;
     }
 
-    int getM(String letterTypes) {
-        if (letterTypes.length() < 2) return 0;
-        if (letterTypes.charAt(0) == 'c') return (letterTypes.length() - 1) / 2;
-        return letterTypes.length() / 2;
+    private boolean containsVowel(StringBuilder sb, int len) {
+        char prev = 0;
+        for (int i = 0; i < len; i++) {
+            char c = sb.charAt(i);
+            if (getLetterType(prev, c) == 'v') return true;
+            prev = c;
+        }
+        return false;
+    }
+
+    private static boolean endsWith(StringBuilder sb, String suffix) {
+        int sufLen = suffix.length();
+        int bufLen = sb.length();
+        if (bufLen < sufLen) return false;
+        int offset = bufLen - sufLen;
+        for (int i = 0; i < sufLen; i++) {
+            if (sb.charAt(offset + i) != suffix.charAt(i)) return false;
+        }
+        return true;
     }
 
     private char getLetterType(char previousLetter, char letter) {

--- a/third-party/porterstemmer/src/main/java/ca/rmen/porterstemmer/PorterStemmerOriginal.java
+++ b/third-party/porterstemmer/src/main/java/ca/rmen/porterstemmer/PorterStemmerOriginal.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2016 Carmen Alvarez
+ *
+ * This file is part of Porter Stemmer.
+ *
+ * Porter Stemmer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Porter Stemmer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Porter Stemmer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ca.rmen.porterstemmer;
+
+import java.util.Locale;
+
+/**
+ * This is a simple implementation of the Porter stemming algorithm, defined here:
+ * <a href="http://tartarus.org/martin/PorterStemmer/def.txt">http://tartarus.org/martin/PorterStemmer/def.txt</a>
+ * <p>
+ * This implementation has not been tuned for high performance on large amounts of text. It is
+ * a simple (naive perhaps) implementation of the rules.
+ */
+public class PorterStemmerOriginal {
+
+    /**
+     * @param word the word to stem
+     * @return the stem of the word, in lowercase.
+     */
+    public String stemWord(String word) {
+        String stem = word.toLowerCase(Locale.getDefault());
+        if (stem.length() < 3) return stem;
+        stem = stemStep1a(stem);
+        stem = stemStep1b(stem);
+        stem = stemStep1c(stem);
+        stem = stemStep2(stem);
+        stem = stemStep3(stem);
+        stem = stemStep4(stem);
+        stem = stemStep5a(stem);
+        stem = stemStep5b(stem);
+        return stem;
+    }
+
+    String stemStep1a(String input) {
+        // SSES -> SS
+        if (input.endsWith("sses")) {
+            return input.substring(0, input.length() - 2);
+        }
+        // IES  -> I
+        if (input.endsWith("ies")) {
+            return input.substring(0, input.length() - 2);
+        }
+        // SS   -> SS
+        if (input.endsWith("ss")) {
+            return input;
+        }
+        // S    ->
+        if (input.endsWith("s")) {
+            return input.substring(0, input.length() - 1);
+        }
+        return input;
+    }
+
+    String stemStep1b(String input) {
+        // (m>0) EED -> EE
+        if (input.endsWith("eed")) {
+            String stem = input.substring(0, input.length() - 1);
+            String letterTypes = getLetterTypes(stem);
+            int m = getM(letterTypes);
+            if (m > 0) return stem;
+            return input;
+        }
+        // (*v*) ED  ->
+        if (input.endsWith("ed")) {
+            String stem = input.substring(0, input.length() - 2);
+            String letterTypes = getLetterTypes(stem);
+            if (letterTypes.contains("v")) {
+                return step1b2(stem);
+            }
+            return input;
+        }
+        // (*v*) ING ->
+        if (input.endsWith("ing")) {
+            String stem = input.substring(0, input.length() - 3);
+            String letterTypes = getLetterTypes(stem);
+            if (letterTypes.contains("v")) {
+                return step1b2(stem);
+            }
+            return input;
+        }
+        return input;
+    }
+
+    private String step1b2(String input) {
+        // AT -> ATE
+        if (input.endsWith("at")) {
+            return input + "e";
+        }
+        // BL -> BLE
+        else if (input.endsWith("bl")) {
+            return input + "e";
+        }
+        // IZ -> IZE
+        else if (input.endsWith("iz")) {
+            return input + "e";
+        } else {
+            // (*d and not (*L or *S or *Z))
+            // -> single letter
+            char lastDoubleConsonant = getLastDoubleConsonant(input);
+            if (lastDoubleConsonant != 0 &&
+                    lastDoubleConsonant != 'l'
+                    && lastDoubleConsonant != 's'
+                    && lastDoubleConsonant != 'z') {
+                return input.substring(0, input.length() - 1);
+            }
+            // (m=1 and *o) -> E
+            else {
+                String letterTypes = getLetterTypes(input);
+                int m = getM(letterTypes);
+                if (m == 1 && isStarO(input)) {
+                    return input + "e";
+                }
+
+            }
+        }
+        return input;
+    }
+
+    String stemStep1c(String input) {
+        if (input.endsWith("y")) {
+            String stem = input.substring(0, input.length() - 1);
+            String letterTypes = getLetterTypes(stem);
+            if (letterTypes.contains("v")) return stem + "i";
+        }
+        return input;
+    }
+
+    String stemStep2(String input) {
+        String[] s1 = new String[]{
+                "ational",
+                "tional",
+                "enci",
+                "anci",
+                "izer",
+                "bli", // the published algorithm specifies abli instead of bli.
+                "alli",
+                "entli",
+                "eli",
+                "ousli",
+                "ization",
+                "ation",
+                "ator",
+                "alism",
+                "iveness",
+                "fulness",
+                "ousness",
+                "aliti",
+                "iviti",
+                "biliti",
+                "logi", // the published algorithm doesn't contain this
+        };
+        String[] s2 = new String[]{
+                "ate",
+                "tion",
+                "ence",
+                "ance",
+                "ize",
+                "ble", // the published algorithm specifies able instead of ble
+                "al",
+                "ent",
+                "e",
+                "ous",
+                "ize",
+                "ate",
+                "ate",
+                "al",
+                "ive",
+                "ful",
+                "ous",
+                "al",
+                "ive",
+                "ble",
+                "log" // the published algorithm doesn't contain this
+        };
+        // (m>0) ATIONAL ->  ATE
+        // (m>0) TIONAL  ->  TION
+        for (int i = 0; i < s1.length; i++) {
+            if (input.endsWith(s1[i])) {
+                String stem = input.substring(0, input.length() - s1[i].length());
+                String letterTypes = getLetterTypes(stem);
+                int m = getM(letterTypes);
+                if (m > 0) return stem + s2[i];
+                return input;
+            }
+        }
+        return input;
+    }
+
+    String stemStep3(String input) {
+        String[] s1 = new String[]{
+                "icate",
+                "ative",
+                "alize",
+                "iciti",
+                "ical",
+                "ful",
+                "ness",
+        };
+        String[] s2 = new String[]{
+                "ic",
+                "",
+                "al",
+                "ic",
+                "ic",
+                "",
+                "",
+        };
+        // (m>0) ICATE ->  IC
+        // (m>0) ATIVE ->
+        for (int i = 0; i < s1.length; i++) {
+            if (input.endsWith(s1[i])) {
+                String stem = input.substring(0, input.length() - s1[i].length());
+                String letterTypes = getLetterTypes(stem);
+                int m = getM(letterTypes);
+                if (m > 0) return stem + s2[i];
+                return input;
+            }
+        }
+        return input;
+
+    }
+
+    String stemStep4(String input) {
+        String[] suffixes = new String[]{
+                "al",
+                "ance",
+                "ence",
+                "er",
+                "ic",
+                "able",
+                "ible",
+                "ant",
+                "ement",
+                "ment",
+                "ent",
+                "ion",
+                "ou",
+                "ism",
+                "ate",
+                "iti",
+                "ous",
+                "ive",
+                "ize",
+        };
+        // (m>1) AL    ->
+        // (m>1) ANCE  ->
+        for(String suffix : suffixes) {
+            if (input.endsWith(suffix)) {
+                String stem = input.substring(0, input.length() - suffix.length());
+                String letterTypes = getLetterTypes(stem);
+                int m = getM(letterTypes);
+                if (m > 1) {
+                    if (suffix.equals("ion")) {
+                        if (stem.charAt(stem.length() - 1) == 's' || stem.charAt(stem.length() - 1) == 't') {
+                            return stem;
+                        }
+                    } else {
+                        return stem;
+                    }
+                }
+                return input;
+            }
+        }
+        return input;
+    }
+
+    String stemStep5a(String input) {
+        if (input.endsWith("e")) {
+            String stem = input.substring(0, input.length() - 1);
+            String letterTypes = getLetterTypes(stem);
+            int m = getM(letterTypes);
+            // (m>1) E     ->
+            if (m > 1) {
+                return stem;
+            }
+            // (m=1 and not *o) E ->
+            if (m == 1 && !isStarO(stem)) {
+                return stem;
+            }
+        }
+        return input;
+    }
+
+    String stemStep5b(String input) {
+        // (m > 1 and *d and *L) -> single letter
+        String letterTypes = getLetterTypes(input);
+        int m = getM(letterTypes);
+        if (m > 1 && input.endsWith("ll")) {
+            return input.substring(0, input.length() - 1);
+        }
+        return input;
+    }
+
+    private char getLastDoubleConsonant(String input) {
+        if (input.length() < 2) return 0;
+        char lastLetter = input.charAt(input.length() - 1);
+        char penultimateLetter = input.charAt(input.length() - 2);
+        if (lastLetter == penultimateLetter && getLetterType((char) 0, lastLetter) == 'c') {
+            return lastLetter;
+        }
+        return 0;
+    }
+
+    // *o  - the stem ends cvc, where the second c is not W, X or Y (e.g.
+    //                                                              -WIL, -HOP)
+    private boolean isStarO(String input) {
+        if (input.length() < 3) return false;
+
+        char lastLetter = input.charAt(input.length() - 1);
+        if (lastLetter == 'w' || lastLetter == 'x' || lastLetter == 'y') return false;
+
+        char secondToLastLetter = input.charAt(input.length() - 2);
+        char thirdToLastLetter = input.charAt(input.length() - 3);
+        char fourthToLastLetter = input.length() == 3 ? 0 : input.charAt(input.length() - 4);
+        return getLetterType(secondToLastLetter, lastLetter) == 'c'
+                && getLetterType(thirdToLastLetter, secondToLastLetter) == 'v'
+                && getLetterType(fourthToLastLetter, thirdToLastLetter) == 'c';
+    }
+
+    String getLetterTypes(String input) {
+        StringBuilder letterTypes = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            char letter = input.charAt(i);
+            char previousLetter = i == 0 ? 0 : input.charAt(i - 1);
+            char letterType = getLetterType(previousLetter, letter);
+            if (letterTypes.length() == 0 || letterTypes.charAt(letterTypes.length() - 1) != letterType) {
+                letterTypes.append(letterType);
+            }
+        }
+        return letterTypes.toString();
+    }
+
+    int getM(String letterTypes) {
+        if (letterTypes.length() < 2) return 0;
+        if (letterTypes.charAt(0) == 'c') return (letterTypes.length() - 1) / 2;
+        return letterTypes.length() / 2;
+    }
+
+    private char getLetterType(char previousLetter, char letter) {
+        switch (letter) {
+            case 'a':
+            case 'e':
+            case 'i':
+            case 'o':
+            case 'u':
+                return 'v';
+            case 'y':
+                if (previousLetter == 0 || getLetterType((char) 0, previousLetter) == 'v') {
+                    return 'c';
+                }
+                return 'v';
+            default:
+                return 'c';
+        }
+    }
+}

--- a/third-party/porterstemmer/src/test/java/ca/rmen/porterstemmer/PorterStemmerOracleTest.java
+++ b/third-party/porterstemmer/src/test/java/ca/rmen/porterstemmer/PorterStemmerOracleTest.java
@@ -1,0 +1,37 @@
+package ca.rmen.porterstemmer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class PorterStemmerOracleTest {
+
+    private static final Path WORDLIST = Path.of("/usr/share/dict/words");
+
+
+    @Test
+    public void test() throws IOException {
+        if (!Files.isRegularFile(WORDLIST)) {
+            return;
+        }
+
+        PorterStemmer current = new PorterStemmer();
+        PorterStemmerOriginal oracle = new PorterStemmerOriginal();
+
+        List<String> words = Files.readAllLines(WORDLIST);
+
+        for (String word : words) {
+            String expected = oracle.stemWord(word);
+            String actual = current.stemWord(word);
+            Assertions.assertEquals(expected, actual, "Mismatch for word: " + word);
+        }
+    }
+
+}


### PR DESCRIPTION
Use StringBuilder instead of raw String concatenation, also hoists some arrays that were being created during stemming.

Result is a 30% speedup and a significant drop in GC churn.  There's probably even more that could be done to speed this up, this change focuses on low hanging fruit.


```
Benchmark                                       Mode  Cnt         Score    Error   Units
StemmerBench.stemCurrent                       thrpt    5        16.205 ±  0.836   ops/s
StemmerBench.stemCurrent:·gc.alloc.rate        thrpt    5       242.245 ± 12.495  MB/sec
StemmerBench.stemCurrent:·gc.alloc.rate.norm   thrpt    5  15675988.441 ±  0.665    B/op
StemmerBench.stemCurrent:·gc.count             thrpt    5        22.000           counts
StemmerBench.stemCurrent:·gc.time              thrpt    5         9.000               ms
StemmerBench.stemOriginal                      thrpt    5        12.344 ±  0.048   ops/s
StemmerBench.stemOriginal:·gc.alloc.rate       thrpt    5       865.929 ±  3.355  MB/sec
StemmerBench.stemOriginal:·gc.alloc.rate.norm  thrpt    5  73566784.320 ±  0.001    B/op
StemmerBench.stemOriginal:·gc.count            thrpt    5       108.000           counts
StemmerBench.stemOriginal:·gc.time             thrpt    5        33.000               ms
```