### PR TITLE
(skiplist) Correctness and performance fixes

### DIFF
--- a/code/libraries/array/java/nu/marginalia/array/pool/BufferPool.java
+++ b/code/libraries/array/java/nu/marginalia/array/pool/BufferPool.java
@@ -130,6 +130,14 @@ public class BufferPool implements AutoCloseable {
 
     }
 
+    public long getDiskReadCount() {
+        return diskReadCount.get();
+    }
+
+    public long getCacheReadCount() {
+        return cacheReadCount.get();
+    }
+
     @Nullable
     public MemoryPage getExistingBufferForReading(long address) {
         MemoryPage cachedBuffer = poolLru.get(address);

--- a/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListReader.java
+++ b/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListReader.java
@@ -114,8 +114,9 @@ public class SkipListReader {
                 maxVal = maxValueInBlock(page, fc, n);
             }
 
-            if (data.peekValueLt(maxVal) > maxVal) {
-                nextBlock = findNextBlock(page, fc, maxVal);
+            long nextNeededValue = data.peekValueLt(maxVal);
+            if (nextNeededValue > maxVal) {
+                nextBlock = findNextBlock(page, fc, nextNeededValue);
             }
             else {
                 nextBlock = currentBlock + BLOCK_STRIDE;
@@ -248,8 +249,6 @@ public class SkipListReader {
     public boolean tryRejectData(@NotNull LongQueryBuffer data) {
         assert data.isAscending();
 
-        assert data.isAscending();
-
         try (var page = indexPool.get(currentBlock)) {
 
             int n = headerNumRecords(page, currentBlockOffset);
@@ -273,8 +272,9 @@ public class SkipListReader {
 
             long nextBlock;
 
-            if (data.peekValueLt(maxVal) > maxVal) {
-                nextBlock = findNextBlock(page, fc, maxVal);
+            long nextNeededValue = data.peekValueLt(maxVal);
+            if (nextNeededValue > maxVal) {
+                nextBlock = findNextBlock(page, fc, nextNeededValue);
             }
             else {
                 nextBlock = currentBlock + BLOCK_STRIDE;

--- a/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListReader.java
+++ b/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListReader.java
@@ -465,7 +465,7 @@ public class SkipListReader {
     /** Fills the buffer with keys from the index.  The caller should use
      * atEnd() to decide when the index has been exhausted.
      *
-     * @return the number of items added to the index
+     * @return the number of items added to the buffer
      * */
     public int getKeys(@NotNull LongQueryBuffer dest, @NotNull SkipListValueRanges ranges)
     {
@@ -502,7 +502,10 @@ public class SkipListReader {
                         long blockMinValue = decompressedData[currentBlockIdx];
                         long rangeEnd;
                         while ((rangeEnd = ranges.end()) < blockMinValue) {
-                            if (!ranges.next()) break outer;
+                            if (!ranges.next()) {
+                                atEnd = true;
+                                break outer;
+                            }
                         }
 
                         long rangeStart = ranges.start();
@@ -518,7 +521,11 @@ public class SkipListReader {
                             int nCopied = dest.addData(decompressedData, dataStart, dataEnd - dataStart);
 
                             totalCopied += nCopied;
-                            currentBlockIdx += nCopied;
+                            currentBlockIdx = dataStart + nCopied;
+
+                            if (nCopied < dataEnd - dataStart) {
+                                return totalCopied;
+                            }
 
                             if (dataEnd == n) {
                                 inRange = true;
@@ -528,16 +535,19 @@ public class SkipListReader {
                     } while (ranges.next());
                 }
                 else {
-                    long blockMinValue = ms.get(ValueLayout.JAVA_LONG, dataOffset);
                     do {
+                        long blockMinValue = ms.get(ValueLayout.JAVA_LONG, dataOffset + 8L * currentBlockIdx);
                         long rangeEnd;
                         while ((rangeEnd = ranges.end()) < blockMinValue) {
-                            if (!ranges.next()) break outer;
+                            if (!ranges.next()) {
+                                atEnd = true;
+                                break outer;
+                            }
                         }
 
                         long rangeStart = ranges.start();
 
-                        int dataStart = page.binarySearchLong(rangeStart, dataOffset, 0, n);
+                        int dataStart = page.binarySearchLong(rangeStart, dataOffset, currentBlockIdx, n);
 
                         if (dataStart == n) {
                             break;
@@ -545,7 +555,15 @@ public class SkipListReader {
 
                         int dataEnd = page.binarySearchLong(rangeEnd, dataOffset, dataStart, n);
                         if (dataStart != dataEnd) {
-                            totalCopied += dest.addData(ms, dataOffset + dataStart * 8L, (dataEnd - dataStart));
+                            int nCopied = dest.addData(ms, dataOffset + dataStart * 8L, dataEnd - dataStart);
+
+                            totalCopied += nCopied;
+                            currentBlockIdx = dataStart + nCopied;
+
+                            if (nCopied < dataEnd - dataStart) {
+                                return totalCopied;
+                            }
+
                             if (dataEnd == n) {
                                 inRange = true;
                                 break;
@@ -558,17 +576,12 @@ public class SkipListReader {
                 if (atEnd)
                     break;
 
-                long nextBlock = currentBlock + (long) BLOCK_STRIDE;
-                long currentValue = ranges.start();
-
-                if (!inRange) {
-                    for (int i = 0; i < fc; i++) {
-                        long nextBlockMaxValue = page.getLong(currentBlockOffset + DATA_BLOCK_HEADER_SIZE + 8 * i);
-                        nextBlock = currentBlock + (long) BLOCK_STRIDE * skipOffsetForPointer(Math.max(0, i - 1));
-                        if (nextBlockMaxValue >= currentValue) {
-                            break;
-                        }
-                    }
+                long nextBlock;
+                if (inRange) {
+                    nextBlock = currentBlock + (long) BLOCK_STRIDE;
+                }
+                else {
+                    nextBlock = findNextBlock(page, fc, ranges.start());
                 }
 
                 currentBlockOffset = 0;

--- a/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListWriter.java
+++ b/code/libraries/skiplist/java/nu/marginalia/skiplist/SkipListWriter.java
@@ -273,7 +273,6 @@ public class SkipListWriter implements AutoCloseable {
                 documentsChannel.write(docsBuffer);
             }
 
-            assert compressorInput.size() == 0 : " Expecting compressor input to be exhausted, has " + compressorInput.size() + " remaining";
             return startPos;
         }
 

--- a/code/libraries/skiplist/test/nu/marginalia/skiplist/SkipListReaderTest.java
+++ b/code/libraries/skiplist/test/nu/marginalia/skiplist/SkipListReaderTest.java
@@ -13,7 +13,9 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.LongStream;
 
@@ -548,6 +550,63 @@ public class SkipListReaderTest {
         }
     }
 
+    @Test
+    public void testRetainSparseBufferFollowsSkipPointers() throws IOException {
+        long[] keys = LongStream.range(0, 1_000_000).map(v -> 2*v).toArray();
+        long[] vals = LongStream.range(0, 1_000_000).map(v -> -v).toArray();
+
+        try (var writer = new SkipListWriter(docsFile, valuesFile)) {
+            writer.writeList(createArray(keys, vals), keys.length);
+        }
+
+        long nBlocks = Files.size(docsFile) / SkipListConstants.BLOCK_SIZE;
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            var reader = new SkipListReader(indexPool, valueReader, 0);
+
+            long[] requestKeys = new long[] { 2, 2*999_999 };
+            LongQueryBuffer lqb = new LongQueryBuffer(requestKeys, requestKeys.length);
+            reader.retainData(lqb);
+            lqb.finalizeFiltering();
+
+            Assertions.assertArrayEquals(requestKeys, lqb.copyData());
+
+            long blocksVisited = indexPool.getDiskReadCount() + indexPool.getCacheReadCount();
+            Assertions.assertTrue(blocksVisited < nBlocks / 8,
+                    "Retain visited " + blocksVisited + " of " + nBlocks
+                            + " blocks, skip pointers do not appear to be used");
+        }
+    }
+
+    @Test
+    public void testRejectSparseBufferFollowsSkipPointers() throws IOException {
+        long[] keys = LongStream.range(0, 1_000_000).map(v -> 2*v).toArray();
+        long[] vals = LongStream.range(0, 1_000_000).map(v -> -v).toArray();
+
+        try (var writer = new SkipListWriter(docsFile, valuesFile)) {
+            writer.writeList(createArray(keys, vals), keys.length);
+        }
+
+        long nBlocks = Files.size(docsFile) / SkipListConstants.BLOCK_SIZE;
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            var reader = new SkipListReader(indexPool, valueReader, 0);
+
+            long[] requestKeys = new long[] { 3, 2*999_999 };
+            LongQueryBuffer lqb = new LongQueryBuffer(requestKeys, requestKeys.length);
+            reader.rejectData(lqb);
+            lqb.finalizeFiltering();
+
+            Assertions.assertArrayEquals(new long[] { 3 }, lqb.copyData());
+
+            long blocksVisited = indexPool.getDiskReadCount() + indexPool.getCacheReadCount();
+            Assertions.assertTrue(blocksVisited < nBlocks / 8,
+                    "Reject visited " + blocksVisited + " of " + nBlocks
+                            + " blocks, skip pointers do not appear to be used");
+        }
+    }
 
     @Tag("slow")
     @Test

--- a/code/libraries/skiplist/test/nu/marginalia/skiplist/SkipListReaderTest.java
+++ b/code/libraries/skiplist/test/nu/marginalia/skiplist/SkipListReaderTest.java
@@ -550,6 +550,103 @@ public class SkipListReaderTest {
         }
     }
 
+
+    @Test
+    public void testGetKeysWithRange__denseRangeLargerThanBuffer() throws IOException {
+        long[] keys = LongStream.range(0, 1000).toArray();
+        long[] vals = LongStream.range(0, 1000).map(v -> -v).toArray();
+
+        try (var writer = new SkipListWriter(docsFile, valuesFile)) {
+            writer.writeList(createArray(keys, vals), keys.length);
+        }
+
+        LongSet actualKeys = new LongArraySet(keys.length);
+        LongSet expectedKeys = new LongArraySet(LongList.of(keys));
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            var reader = new SkipListReader(indexPool, valueReader, 0);
+            LongQueryBuffer lqb = new LongQueryBuffer(20);
+
+            SkipListValueRanges ranges = new SkipListValueRanges(new long[] { 0 }, new long[] { 1000 });
+
+            while (!reader.atEnd()) {
+                reader.getKeys(lqb, ranges);
+                actualKeys.addAll(LongList.of(lqb.copyData()));
+                if (!lqb.fitsMore()) {
+                    lqb.zero();
+                }
+            }
+        }
+
+        Assertions.assertEquals(expectedKeys, actualKeys);
+    }
+
+    @Test
+    public void testGetKeysWithRange__twoRangesLargerThanBuffer() throws IOException {
+        long[] keys = LongStream.range(0, 1000).toArray();
+        long[] vals = LongStream.range(0, 1000).map(v -> -v).toArray();
+
+        try (var writer = new SkipListWriter(docsFile, valuesFile)) {
+            writer.writeList(createArray(keys, vals), keys.length);
+        }
+
+        LongSet actualKeys = new LongArraySet(keys.length);
+        LongSet expectedKeys = new LongArraySet();
+        for (long i = 0; i < 100; i++) expectedKeys.add(i);
+        for (long i = 500; i < 600; i++) expectedKeys.add(i);
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            var reader = new SkipListReader(indexPool, valueReader, 0);
+            LongQueryBuffer lqb = new LongQueryBuffer(20);
+
+            SkipListValueRanges ranges = new SkipListValueRanges(new long[] { 0, 500 }, new long[] { 100, 600 });
+
+            while (!reader.atEnd()) {
+                reader.getKeys(lqb, ranges);
+                actualKeys.addAll(LongList.of(lqb.copyData()));
+                if (!lqb.fitsMore()) {
+                    lqb.zero();
+                }
+            }
+        }
+
+        Assertions.assertEquals(expectedKeys, actualKeys);
+    }
+
+    @Test
+    public void testGetKeysWithRange__multiBlockRangeLargerThanBuffer() throws IOException {
+        long[] keys = LongStream.range(0, 32000).toArray();
+        long[] vals = LongStream.range(0, 32000).map(v -> -v).toArray();
+
+        try (var writer = new SkipListWriter(docsFile, valuesFile)) {
+            writer.writeList(createArray(keys, vals), keys.length);
+        }
+
+        LongSet actualKeys = new LongArraySet(keys.length);
+        LongSet expectedKeys = new LongArraySet();
+        for (long i = 1000; i < 9000; i++) expectedKeys.add(i);
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            var reader = new SkipListReader(indexPool, valueReader, 0);
+            LongQueryBuffer lqb = new LongQueryBuffer(512);
+
+            SkipListValueRanges ranges = new SkipListValueRanges(new long[] { 1000 }, new long[] { 9000 });
+
+            while (!reader.atEnd()) {
+                reader.getKeys(lqb, ranges);
+                actualKeys.addAll(LongList.of(lqb.copyData()));
+                if (!lqb.fitsMore()) {
+                    lqb.zero();
+                }
+            }
+        }
+
+        Assertions.assertEquals(expectedKeys, actualKeys);
+    }
+
     @Test
     public void testRetainSparseBufferFollowsSkipPointers() throws IOException {
         long[] keys = LongStream.range(0, 1_000_000).map(v -> 2*v).toArray();
@@ -605,6 +702,43 @@ public class SkipListReaderTest {
             Assertions.assertTrue(blocksVisited < nBlocks / 8,
                     "Reject visited " + blocksVisited + " of " + nBlocks
                             + " blocks, skip pointers do not appear to be used");
+        }
+    }
+
+    @Test
+    public void testParseFuzz_seed15() throws IOException {
+        Random r = new Random(15);
+
+        List<long[]> keysForBlocks = new ArrayList<>();
+
+        for (int i = 0; i < 1000; i++) {
+            int nVals = r.nextInt(8, SkipListConstants.MAX_RECORDS_PER_BLOCK);
+            long[] keys = new long[nVals];
+            for (int ki = 0; ki < keys.length; ki++) {
+                keys[ki] = r.nextLong(0, Long.MAX_VALUE);
+            }
+
+            Arrays.sort(keys);
+            keysForBlocks.add(keys);
+        }
+
+        List<Long> offsets = new ArrayList<>();
+        Files.delete(docsFile);
+        try (var writer = new SkipListWriter(docsFile, valuesFile);
+             Arena arena = Arena.ofConfined()
+        ) {
+            writer.padDocuments(r.nextInt(0, SkipListConstants.BLOCK_SIZE/8) * 8);
+            for (var block : keysForBlocks) {
+                offsets.add(writer.writeList(createArray(arena, block, block), block.length));
+            }
+        }
+
+        try (var indexPool = new BufferPool(docsFile, SkipListConstants.BLOCK_SIZE, 8);
+             var valueReader = new SkipListValueReader(valuesFile)) {
+            for (var offset : offsets) {
+                var reader = new SkipListReader(indexPool, valueReader, offset);
+                reader.parseBlocks(indexPool, offset);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes two bugs in the skiplist reader:

* Retain and reject were not using skip pointers correctly, leading to an unnecessary amount of disk read operations in some scenarios.

* SkipListValueRange-based operations did not resume correctly, leading to rare cases where not all documents in the index would be considered during ranking.