### PR TITLE
Allow launching processes as tranisent systemd units

### DIFF
--- a/code/execution/java/nu/marginalia/process/AbstractProcessSpawnerService.java
+++ b/code/execution/java/nu/marginalia/process/AbstractProcessSpawnerService.java
@@ -1,0 +1,228 @@
+package nu.marginalia.process;
+
+import nu.marginalia.WmsaHome;
+import nu.marginalia.service.control.ServiceEventLog;
+import nu.marginalia.service.server.BaseServiceParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class AbstractProcessSpawnerService implements ProcessSpawnerService {
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Marker processMarker = MarkerFactory.getMarker("PROCESS");
+
+    private final ServiceEventLog eventLog;
+
+    private final ConcurrentHashMap<ProcessId, Process> processes = new ConcurrentHashMap<>();
+    protected final int node;
+
+    protected AbstractProcessSpawnerService(BaseServiceParams params) {
+        this.eventLog = params.eventLog;
+        this.node = params.configuration.node();
+    }
+
+    /** Embeds the java invocation in the launch mechanism.  The default launches it
+     * as-is, directly as a child process. */
+    protected List<String> wrapCommand(ProcessId processId, List<String> javaCommand) throws Exception {
+        return javaCommand;
+    }
+
+    /** Terminates a process previously launched by wrapCommand.  The default destroys
+     * the child process. */
+    protected void destroyProcess(ProcessId processId, Process process) {
+        process.destroy();
+    }
+
+    /** Judges the outcome of a finished process from the watcher's exit code.  The
+     * default takes the exit code at face value, appropriate when the watcher is the
+     * process itself. */
+    protected boolean interpretResult(ProcessId processId, int exitCode) {
+        return exitCode == 0;
+    }
+
+    public boolean trigger(ProcessId processId, String... extraArgs) throws Exception {
+        final String[] env = createEnvironmentVariables();
+        final List<String> args = wrapCommand(processId, createJavaCommand(processId, extraArgs));
+
+        Process process;
+
+        logger.info("Starting process: {} {}", processId, processId.envOpts());
+
+        synchronized (processes) {
+            if (processes.containsKey(processId)) return false;
+            process = Runtime.getRuntime().exec(args.toArray(String[]::new), env);
+            processes.put(processId, process);
+        }
+
+        eventLog.logEvent("PROCESS-START", processId.toString());
+        try {
+            new Thread(new ProcessLogStderr(process)).start();
+            new Thread(new ProcessLogStdout(process)).start();
+
+            final int returnCode = process.waitFor();
+            logger.info("Process {} terminated with code {}", processId, returnCode);
+            return interpretResult(processId, returnCode);
+        }
+        catch (Exception ex) {
+            logger.info("Process {} terminated with exception", processId);
+            throw ex;
+        }
+        finally {
+            eventLog.logEvent("PROCESS-EXIT", processId.toString());
+            processes.remove(processId);
+        }
+    }
+
+    private List<String> createJavaCommand(ProcessId processId, String... extraArgs) {
+        List<String> args = new ArrayList<>();
+        String javaHome = System.getProperty("java.home");
+
+        args.add(javaHome + "/bin/java");
+        args.add("-cp");
+        args.add(System.getProperty("java.class.path"));
+
+        if (getClass().desiredAssertionStatus()) args.add("-ea");
+        else args.add("-da");
+
+        args.add("--enable-preview");
+        args.add("--enable-native-access=ALL-UNNAMED");
+
+        args.add("-Dservice-name=" + processId.processName);
+
+        String loggingOpts = System.getProperty("log4j2.configurationFile");
+        if (loggingOpts != null) {
+            args.add("-Dlog4j.configurationFile=" + loggingOpts);
+        }
+
+        if (System.getProperty("system.serviceNode") != null) {
+            args.add("-Dsystem.serviceNode=" + System.getProperty("system.serviceNode"));
+        }
+
+        // Add SOCKS proxy properties for crawler processes
+        if (System.getProperty("crawler.socksProxy.enabled") != null) {
+            args.add("-Dcrawler.socksProxy.enabled=" + System.getProperty("crawler.socksProxy.enabled"));
+        }
+        if (System.getProperty("crawler.socksProxy.list") != null) {
+            args.add("-Dcrawler.socksProxy.list=" + System.getProperty("crawler.socksProxy.list"));
+        }
+        if (System.getProperty("crawler.socksProxy.strategy") != null) {
+            args.add("-Dcrawler.socksProxy.strategy=" + System.getProperty("crawler.socksProxy.strategy"));
+        }
+
+        if (Boolean.getBoolean("system.profile")) {
+            // add jfr options
+            args.add("-XX:+FlightRecorder");
+            String jfrFileName = "/var/log/wmsa/profile-%s-%d-%s.jfr".formatted(
+                    processId.toString(),
+                    node,
+                    LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME).replace(':', '.')
+            );
+            args.add("-XX:StartFlightRecording=filename=%s,name=%s".formatted(jfrFileName, processId.toString()));
+        }
+
+        args.addAll(processId.envOpts());
+        args.add(processId.mainClass);
+        args.addAll(Arrays.asList(extraArgs));
+
+        return args;
+    }
+
+    public boolean isRunning(ProcessId processId) {
+        return processes.containsKey(processId);
+    }
+
+    public boolean kill(ProcessId processId) {
+        Process process = processes.get(processId);
+        if (process == null) return false;
+
+        eventLog.logEvent("PROCESS-KILL", processId.toString());
+        destroyProcess(processId, process);
+
+        return true;
+    }
+
+    /** These environment variables are propagated from the parent process to the child process,
+     * along with WMSA_HOME, but it has special logic */
+    private final List<String> propagatedEnvironmentVariables = List.of(
+            "ZOOKEEPER_HOSTS",
+            "WMSA_SERVICE_NODE"
+    );
+
+    protected List<String> createEnvironmentVariablesList() {
+        List<String> opts = new ArrayList<>();
+
+        opts.add(env2str("WMSA_HOME", WmsaHome.getHomePath().toString()));
+
+        for (String envKey : propagatedEnvironmentVariables) {
+            String envValue = System.getenv(envKey);
+            if (envValue != null && !envValue.isBlank()) {
+                opts.add(env2str(envKey, envValue));
+            }
+        }
+
+        return opts;
+    }
+
+    private String[] createEnvironmentVariables() {
+        return createEnvironmentVariablesList().toArray(String[]::new);
+    }
+
+    private String env2str(String key, String val) {
+        return key + "=" + val;
+    }
+
+
+    class ProcessLogStderr implements Runnable {
+        private final Process process;
+
+        public ProcessLogStderr(Process process) {
+            this.process = process;
+        }
+
+        @Override
+        public void run() {
+            try (var es = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+                String line;
+                while (((line = es.readLine()) != null)) {
+                    logger.warn(processMarker, line);
+                }
+            }
+            catch (IOException ex) {
+                logger.error("Error reading process error stream", ex);
+            }
+        }
+    }
+
+    class ProcessLogStdout implements Runnable {
+        private final Process process;
+
+        public ProcessLogStdout(Process process) {
+            this.process = process;
+        }
+
+        @Override
+        public void run() {
+            try (var is = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while (((line = is.readLine()) != null)) {
+                    logger.info(processMarker, line);
+                }
+            }
+            catch (IOException ex) {
+                logger.error("Error reading process output stream", ex);
+            }
+        }
+    }
+
+}

--- a/code/execution/java/nu/marginalia/process/ForkingProcessSpawnerService.java
+++ b/code/execution/java/nu/marginalia/process/ForkingProcessSpawnerService.java
@@ -1,0 +1,18 @@
+package nu.marginalia.process;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import nu.marginalia.service.server.BaseServiceParams;
+
+/** Spawns the batch processes as direct children of the service, sharing its execution
+ * environment.  This is the default spawner, and the appropriate one for docker
+ * deployments.
+ */
+@Singleton
+public class ForkingProcessSpawnerService extends AbstractProcessSpawnerService {
+
+    @Inject
+    public ForkingProcessSpawnerService(BaseServiceParams params) {
+        super(params);
+    }
+}

--- a/code/execution/java/nu/marginalia/process/ProcessSpawnerService.java
+++ b/code/execution/java/nu/marginalia/process/ProcessSpawnerService.java
@@ -1,44 +1,19 @@
 package nu.marginalia.process;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import nu.marginalia.WmsaHome;
 import nu.marginalia.converting.ConverterMain;
 import nu.marginalia.crawl.CrawlerMain;
 import nu.marginalia.livecrawler.LiveCrawlerMain;
 import nu.marginalia.loading.LoaderMain;
 import nu.marginalia.ndp.NdpMain;
 import nu.marginalia.ping.PingMain;
-import nu.marginalia.service.control.ServiceEventLog;
-import nu.marginalia.service.server.BaseServiceParams;
 import nu.marginalia.task.ExportTasksMain;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
-@Singleton
-public class ProcessSpawnerService {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Marker processMarker = MarkerFactory.getMarker("PROCESS");
+public interface ProcessSpawnerService {
 
-    private final ServiceEventLog eventLog;
-
-    private final ConcurrentHashMap<ProcessId, Process> processes = new ConcurrentHashMap<>();
-    private final int node;
-
-
-    public static ProcessId translateExternalIdBase(String id) {
+    static ProcessId translateExternalIdBase(String id) {
         for (var processId : ProcessId.values()) {
             if (processId.processName.equals(id))
                 return processId;
@@ -46,7 +21,7 @@ public class ProcessSpawnerService {
         return null;
     }
 
-    public enum ProcessId {
+    enum ProcessId {
         CRAWLER(CrawlerMain.class, "crawler"),
         PING(PingMain.class, "ping"),
         LIVE_CRAWLER(LiveCrawlerMain.class, "live-crawler"),
@@ -91,178 +66,13 @@ public class ProcessSpawnerService {
         }
     }
 
-    @Inject
-    public ProcessSpawnerService(BaseServiceParams params) {
-        this.eventLog = params.eventLog;
-        this.node = params.configuration.node();
-    }
+    /** Starts the process and blocks until it terminates, returning true if it exited
+     * successfully.  Returns false without starting anything if the process is already
+     * running on this node. */
+    boolean trigger(ProcessId processId, String... extraArgs) throws Exception;
 
+    boolean isRunning(ProcessId processId);
 
-    public boolean trigger(ProcessId processId, String... extraArgs) throws Exception {
-        final String[] env = createEnvironmentVariables();
-        List<String> args = new ArrayList<>();
-        String javaHome = System.getProperty("java.home");
-
-        args.add(javaHome + "/bin/java");
-        args.add("-cp");
-        args.add(System.getProperty("java.class.path"));
-
-        if (getClass().desiredAssertionStatus()) args.add("-ea");
-        else args.add("-da");
-
-        args.add("--enable-preview");
-        args.add("--enable-native-access=ALL-UNNAMED");
-
-        args.add("-Dservice-name=" + processId.processName);
-
-        String loggingOpts = System.getProperty("log4j2.configurationFile");
-        if (loggingOpts != null) {
-            args.add("-Dlog4j.configurationFile=" + loggingOpts);
-        }
-
-        if (System.getProperty("system.serviceNode") != null) {
-            args.add("-Dsystem.serviceNode=" + System.getProperty("system.serviceNode"));
-        }
-
-        // Add SOCKS proxy properties for crawler processes
-        if (System.getProperty("crawler.socksProxy.enabled") != null) {
-            args.add("-Dcrawler.socksProxy.enabled=" + System.getProperty("crawler.socksProxy.enabled"));
-        }
-        if (System.getProperty("crawler.socksProxy.list") != null) {
-            args.add("-Dcrawler.socksProxy.list=" + System.getProperty("crawler.socksProxy.list"));
-        }
-        if (System.getProperty("crawler.socksProxy.strategy") != null) {
-            args.add("-Dcrawler.socksProxy.strategy=" + System.getProperty("crawler.socksProxy.strategy"));
-        }
-
-        if (Boolean.getBoolean("system.profile")) {
-            // add jfr options
-            args.add("-XX:+FlightRecorder");
-            String jfrFileName = "/var/log/wmsa/profile-%s-%d-%s.jfr".formatted(
-                    processId.toString(),
-                    node,
-                    LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME).replace(':', '.')
-            );
-            args.add("-XX:StartFlightRecording=filename=%s,name=%s".formatted(jfrFileName, processId.toString()));
-        }
-
-        args.addAll(processId.envOpts());
-        args.add(processId.mainClass);
-        args.addAll(Arrays.asList(extraArgs));
-
-        Process process;
-
-        logger.info("Starting process: {} {}", processId, processId.envOpts());
-
-        synchronized (processes) {
-            if (processes.containsKey(processId)) return false;
-            process = Runtime.getRuntime().exec(args.toArray(String[]::new), env);
-            processes.put(processId, process);
-        }
-
-        eventLog.logEvent("PROCESS-START", processId.toString());
-        try {
-            new Thread(new ProcessLogStderr(process)).start();
-            new Thread(new ProcessLogStdout(process)).start();
-
-            final int returnCode = process.waitFor();
-            logger.info("Process {} terminated with code {}", processId, returnCode);
-            return 0 == returnCode;
-        }
-        catch (Exception ex) {
-            logger.info("Process {} terminated with exception", processId);
-            throw ex;
-        }
-        finally {
-            eventLog.logEvent("PROCESS-EXIT", processId.toString());
-            processes.remove(processId);
-        }
-    }
-
-
-    public boolean isRunning(ProcessId processId) {
-        return processes.containsKey(processId);
-    }
-
-    public boolean kill(ProcessId processId) {
-        Process process = processes.get(processId);
-        if (process == null) return false;
-
-        eventLog.logEvent("PROCESS-KILL", processId.toString());
-        process.destroy();
-
-        return true;
-    }
-
-    /** These environment variables are propagated from the parent process to the child process,
-     * along with WMSA_HOME, but it has special logic */
-    private final List<String> propagatedEnvironmentVariables = List.of(
-            "ZOOKEEPER_HOSTS",
-            "WMSA_SERVICE_NODE"
-    );
-
-    private String[] createEnvironmentVariables() {
-        List<String> opts = new ArrayList<>();
-
-        opts.add(env2str("WMSA_HOME", WmsaHome.getHomePath().toString()));
-
-        for (String envKey : propagatedEnvironmentVariables) {
-            String envValue = System.getenv(envKey);
-            if (envValue != null && !envValue.isBlank()) {
-                opts.add(env2str(envKey, envValue));
-            }
-        }
-
-        return opts.toArray(String[]::new);
-    }
-
-    private String env2str(String key, String val) {
-        return key + "=" + val;
-    }
-
-
-
-
-    class ProcessLogStderr implements Runnable {
-        private final Process process;
-
-        public ProcessLogStderr(Process process) {
-            this.process = process;
-        }
-
-        @Override
-        public void run() {
-            try (var es = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-                String line;
-                while (((line = es.readLine()) != null)) {
-                    logger.warn(processMarker, line);
-                }
-            }
-            catch (IOException ex) {
-                logger.error("Error reading process error stream", ex);
-            }
-        }
-    }
-
-    class ProcessLogStdout implements Runnable {
-        private final Process process;
-
-        public ProcessLogStdout(Process process) {
-            this.process = process;
-        }
-
-        @Override
-        public void run() {
-            try (var is = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while (((line = is.readLine()) != null)) {
-                    logger.info(processMarker, line);
-                }
-            }
-            catch (IOException ex) {
-                logger.error("Error reading process output stream", ex);
-            }
-        }
-    }
-
+    /** Requests termination of the process.  Returns false if it was not running. */
+    boolean kill(ProcessId processId);
 }

--- a/code/execution/java/nu/marginalia/process/SystemdProcessSpawnerService.java
+++ b/code/execution/java/nu/marginalia/process/SystemdProcessSpawnerService.java
@@ -1,0 +1,216 @@
+package nu.marginalia.process;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import nu.marginalia.service.server.BaseServiceParams;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Spawns the batch processes as transient systemd units via systemd-run.
+ * <p>
+ * The service user needs authorization to manage the transient units, which is
+ * granted with a polkit rule scoped to the marginalia-proc- unit name prefix.
+ */
+@Singleton
+public class SystemdProcessSpawnerService extends AbstractProcessSpawnerService {
+
+    private static final String UNIT_PREFIX = "marginalia_proc-";
+
+    /** Sandbox properties replayed from the service's unit onto the transient units.
+     * Resource constraints such CPUAffinity and NUMAPolicy are deliberately excluded. */
+    private static final List<String> SANDBOX_PROPERTIES = List.of(
+            "User",
+            "Group",
+            "Slice",
+            "PrivateMounts",
+            "BindPaths",
+            "BindReadOnlyPaths",
+            "NetworkNamespacePath",
+            "LimitNOFILE"
+    );
+
+    private volatile Map<String, String> sandboxProperties = null;
+
+    @Inject
+    public SystemdProcessSpawnerService(BaseServiceParams params) {
+        super(params);
+    }
+
+    @Override
+    protected List<String> wrapCommand(ProcessId processId, List<String> javaCommand) throws Exception {
+        // Recover a running process
+        if (isUnitActive(processId)) {
+            logger.info("Adopting already-running unit {}", unitName(processId));
+            return List.of("/usr/bin/systemctl", "start", "--wait", unitName(processId));
+        }
+
+        // A unit that failed lingers in failed state as the outcome signal (see
+        // interpretResult()), clear any such leftover so the name is free
+        resetFailedUnit(processId);
+
+        List<String> command = new ArrayList<>();
+
+        command.add("/usr/bin/systemd-run");
+        command.add("--unit=" + unitName(processId));
+        command.add("--description=Marginalia " + processId.processName + " process, node " + node);
+        command.add("--wait");
+        command.add("--quiet");
+        command.add("--property=PartOf=marginalia.target");
+
+        // The JVM exits 143 on SIGTERM
+        command.add("--property=SuccessExitStatus=143");
+        String nsPath = sandboxProperties().get("NetworkNamespacePath");
+        if (nsPath != null && !nsPath.isBlank()) {
+            String nsUnit = "marginalia_netns@" + nsPath.substring(nsPath.lastIndexOf('/') + 1) + ".service";
+            command.add("--property=BindsTo=" + nsUnit);
+            command.add("--property=After=" + nsUnit);
+        }
+
+        for (Map.Entry<String, String> property : sandboxProperties().entrySet()) {
+            command.add("--property=" + property.getKey() + "=" + property.getValue());
+        }
+
+        for (String env : createEnvironmentVariablesList()) {
+            command.add("--setenv=" + env);
+        }
+
+        command.add("--");
+        command.addAll(javaCommand);
+
+        return command;
+    }
+
+    @Override
+    public boolean isRunning(ProcessId processId) {
+        // The in-memory bookkeeping does not survive service restarts, but the unit
+        // does thanks to a deterministic name
+        return super.isRunning(processId) || isUnitActive(processId);
+    }
+
+    @Override
+    protected boolean interpretResult(ProcessId processId, int exitCode) {
+        // The adoption path's watcher cannot propagate the process exit status.
+        //
+        // The unit's failure state is the outcome signal instead.  A tarnsient unit
+        // that fails lingers in failed state, a successful one unloads when it exits
+        boolean failed = isUnitFailed(processId);
+        if (failed) {
+            resetFailedUnit(processId);
+        }
+        return exitCode == 0 && !failed;
+    }
+
+    @Override
+    protected void destroyProcess(ProcessId processId, Process process) {
+        try {
+            int returnCode = systemctl("stop", unitName(processId));
+            // Exit code 5 means the unit was not loaded, i.e. nothing left to stop
+            if (returnCode != 0 && returnCode != 5) {
+                logger.error("systemctl stop {} failed with code {}", unitName(processId), returnCode);
+            }
+        }
+        catch (Exception ex) {
+            logger.error("Failed to stop unit " + unitName(processId), ex);
+        }
+    }
+
+    private boolean isUnitActive(ProcessId processId) {
+        try {
+            return systemctl("is-active", "--quiet", unitName(processId)) == 0;
+        }
+        catch (Exception ex) {
+            logger.error("Failed to query unit " + unitName(processId), ex);
+            return false;
+        }
+    }
+
+    private boolean isUnitFailed(ProcessId processId) {
+        try {
+            return systemctl("is-failed", "--quiet", unitName(processId)) == 0;
+        }
+        catch (Exception ex) {
+            logger.error("Failed to query unit " + unitName(processId), ex);
+            return false;
+        }
+    }
+
+    private void resetFailedUnit(ProcessId processId) {
+        try {
+            // Fails when there is nothing to reset, which is the common case
+            systemctl("reset-failed", unitName(processId));
+        }
+        catch (Exception ex) {
+            logger.error("Failed to reset unit " + unitName(processId), ex);
+        }
+    }
+
+    private int systemctl(String... args) throws IOException, InterruptedException {
+        List<String> command = new ArrayList<>();
+        command.add("/usr/bin/systemctl");
+        command.addAll(List.of(args));
+        return Runtime.getRuntime().exec(command.toArray(String[]::new)).waitFor();
+    }
+
+    private String unitName(ProcessId processId) {
+        return UNIT_PREFIX + processId.processName + "-" + node + ".service";
+    }
+
+    private Map<String, String> sandboxProperties() throws IOException, InterruptedException {
+        if (sandboxProperties == null) {
+            sandboxProperties = querySandboxProperties(ownUnitName());
+        }
+        return sandboxProperties;
+    }
+
+    private Map<String, String> querySandboxProperties(String serviceUnit) throws IOException, InterruptedException {
+        List<String> command = new ArrayList<>();
+        command.add("/usr/bin/systemctl");
+        command.add("show");
+        command.add(serviceUnit);
+        for (String property : SANDBOX_PROPERTIES) {
+            command.add("-p");
+            command.add(property);
+        }
+
+        Process show = Runtime.getRuntime().exec(command.toArray(String[]::new));
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        try (var reader = new BufferedReader(new InputStreamReader(show.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                int eq = line.indexOf('=');
+                if (eq > 0 && eq < line.length() - 1) {
+                    properties.put(line.substring(0, eq), line.substring(eq + 1));
+                }
+            }
+        }
+
+        int returnCode = show.waitFor();
+        if (returnCode != 0) {
+            throw new IOException("systemctl show " + serviceUnit + " failed with code " + returnCode);
+        }
+
+        logger.info("Transient unit sandbox from {}: {}", serviceUnit, properties);
+
+        return properties;
+    }
+
+    /** The unit name of the service itself, from its cgroup path. */
+    private String ownUnitName() throws IOException {
+        for (String line : Files.readAllLines(Path.of("/proc/self/cgroup"))) {
+            String unit = line.substring(line.lastIndexOf('/') + 1);
+            if (unit.endsWith(".service")) {
+                return unit;
+            }
+        }
+        throw new IllegalStateException("??? Cannot detemrine own unit name from /proc/self/cgroup ???");
+    }
+}

--- a/code/services-core/index-service/java/nu/marginalia/index/IndexModule.java
+++ b/code/services-core/index-service/java/nu/marginalia/index/IndexModule.java
@@ -6,6 +6,9 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import nu.marginalia.linkgraph.DomainLinks;
 import nu.marginalia.linkgraph.impl.DelayingDomainLinks;
+import nu.marginalia.process.ForkingProcessSpawnerService;
+import nu.marginalia.process.ProcessSpawnerService;
+import nu.marginalia.process.SystemdProcessSpawnerService;
 import nu.marginalia.storage.FileStorageService;
 import nu.marginalia.IndexLocations;
 import org.slf4j.Logger;
@@ -22,13 +25,19 @@ public class IndexModule extends AbstractModule {
     private static final Logger logger = LoggerFactory.getLogger(IndexModule.class);
 
     public void configure() {
+        // Batch processes normally run as child processes of the service, but systemd
+        // deployments can opt to run them as transient systemd units instead.
+        if ("systemd".equals(System.getProperty("process.spawner", "fork"))) {
+            bind(ProcessSpawnerService.class).to(SystemdProcessSpawnerService.class);
+        }
+        else {
+            bind(ProcessSpawnerService.class).to(ForkingProcessSpawnerService.class);
+        }
     }
 
     @Provides
     @Singleton
-    public DomainLinks domainLinkDb (
-            FileStorageService storageService
-            )
+    public DomainLinks domainLinkDb(FileStorageService storageService)
     {
         Path path = IndexLocations.getLinkdbLivePath(storageService).resolve(DOMAIN_LINKS_FILE_NAME);
 


### PR DESCRIPTION
This is a bit of a cursed hack to allow the system, when run via systemd, to launch its processes as transient systemd units.  This is mostly necessary on multi-CPU servers, where you definitely want NUMA affinities on the index, but don't want these to be inherited by CPU-intensive but timing-insensitive processing jobs.

This is a very experimental change and we're making a lot of assumptions around the setup that probably won't hold in general.  