### PR TITLE
Implement unranked queries

### DIFF
--- a/code/common/service/java/nu/marginalia/service/client/GrpcSingleNodeChannelPool.java
+++ b/code/common/service/java/nu/marginalia/service/client/GrpcSingleNodeChannelPool.java
@@ -277,6 +277,17 @@ public class GrpcSingleNodeChannelPool<STUB> extends ServiceChangeMonitor {
         return channels.values().stream().sorted().toList();
     }
 
+    public Optional<ConnectionHolder> getBestConnectionHolder() {
+
+        for (var h : getConnectionHolders()) {
+            if (h.hasErrorSince(Duration.ofSeconds(5)))
+                continue;
+            return Optional.of(h);
+        }
+
+        return Optional.empty();
+    }
+
     public <T, I> T call(Function<ManagedChannel, STUB> stubConstructor,
                           BiFunction<STUB, I, T> call,
                           I arg) throws RuntimeException {

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryClient.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryClient.java
@@ -60,7 +60,7 @@ public class QueryClient  {
     public UnrankedQueryResponse unrankedSearch(List<String> terms,
                                                 String languageIsoCode,
                                                 RpcQueryLimits limits,
-                                                @Nullable String cursorEncoded) {
+                                                @Nullable String cursorEncoded) throws TimeoutException {
         RpcQsUnrankedQuery.Builder queryBuilder = RpcQsUnrankedQuery.newBuilder();
 
         queryBuilder.setLangIsoCode(languageIsoCode);

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryClient.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryClient.java
@@ -6,6 +6,7 @@ import io.grpc.ManagedChannel;
 import io.prometheus.metrics.core.metrics.Summary;
 import nu.marginalia.api.searchquery.model.query.NsfwFilterTier;
 import nu.marginalia.api.searchquery.model.query.QueryResponse;
+import nu.marginalia.api.searchquery.model.query.UnrankedQueryResponse;
 import nu.marginalia.service.client.GrpcChannelPoolFactoryIf;
 import nu.marginalia.service.client.GrpcSingleNodeChannelPool;
 import nu.marginalia.service.discovery.property.ServiceKey;
@@ -15,8 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.*;
 
 @Singleton
@@ -29,7 +32,10 @@ public class QueryClient  {
             .name("wmsa_qs_api_search_time")
             .help("query service search time")
             .register();
-
+    private static final Summary wmsa_qs_api_search_unranked_time = Summary.builder()
+            .name("wmsa_qs_api_search_unranked_time")
+            .help("query service unranked search time")
+            .register();
     private final GrpcSingleNodeChannelPool<QueryApiGrpc.QueryApiBlockingStub> queryApiPool;
 
     @Inject
@@ -49,6 +55,28 @@ public class QueryClient  {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    public UnrankedQueryResponse unrankedSearch(List<String> terms,
+                                                String languageIsoCode,
+                                                RpcQueryLimits limits,
+                                                @Nullable String cursorEncoded) {
+        RpcQsUnrankedQuery.Builder queryBuilder = RpcQsUnrankedQuery.newBuilder();
+
+        queryBuilder.setLangIsoCode(languageIsoCode);
+        queryBuilder.addAllTermsRequired(terms);
+        queryBuilder.setQueryLimits(limits);
+        queryBuilder.setEncodedCursor(Objects.requireNonNullElse(cursorEncoded, ""));
+
+        try (var _ = wmsa_qs_api_search_unranked_time.startTimer()) {
+            RpcQsUnrankedResponse rsp = queryApiPool.call(
+                    channel -> QueryApiGrpc.newBlockingStub(channel)
+                            .withDeadlineAfter(Duration.ofMillis(limits.getTimeoutMs() * 2)),
+                    QueryApiGrpc.QueryApiBlockingStub::unrankedQuery,
+                    queryBuilder.build());
+
+            return QueryProtobufCodec.convertQueryResponse(rsp);
+        }
     }
 
     @CheckReturnValue

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryProtobufCodec.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryProtobufCodec.java
@@ -17,6 +17,15 @@ import java.util.Map;
 
 public class QueryProtobufCodec {
 
+    public static UnrankedQueryResponse convertQueryResponse(RpcQsUnrankedResponse rsp) {
+        var results = new ArrayList<DecoratedSearchResultItem>(rsp.getResultsCount());
+
+        for (int i = 0; i < rsp.getResultsCount(); i++) {
+            results.add(convertDecoratedResult(rsp.getResults(i)));
+        }
+
+        return new UnrankedQueryResponse(results, rsp.getEncodedCursor());
+    }
 
     public static QueryResponse convertQueryResponse(RpcQsResponse rsp) {
         var results = new ArrayList<DecoratedSearchResultItem>(rsp.getResultsCount());

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/UnrankedQueryResponse.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/query/UnrankedQueryResponse.java
@@ -1,0 +1,11 @@
+package nu.marginalia.api.searchquery.model.query;
+
+import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
+
+import java.util.List;
+
+public record UnrankedQueryResponse(List<DecoratedSearchResultItem> results, String encodedCursor) {
+    public boolean hasMore() {
+        return !"FIN".equals(encodedCursor);
+    }
+}

--- a/code/functions/search-query/api/src/main/protobuf/query-api.proto
+++ b/code/functions/search-query/api/src/main/protobuf/query-api.proto
@@ -8,8 +8,10 @@ service QueryApi {
   rpc query(RpcQsQuery) returns (RpcQsResponse) {}
   rpc invalidateFilterCache(RpcQsInvalidateFilter) returns (Empty) {}
 }
+
 service IndexApi {
   rpc query(RpcIndexQuery) returns (RpcIndexQueryResponse) {}
+  rpc unrankedQuery(RpcIndexUnrankedQuery) returns (RpcIndexQueryResponse) {}
 }
 
 message Empty {}
@@ -99,6 +101,21 @@ message RpcTemporalBias {
   Bias bias = 1;
 }
 
+message RpcIndexUnrankedQuery {
+  repeated string termsRequired = 1;
+  repeated string termsExcluded = 2;
+
+  repeated int32 requiredDomainIds = 10;     // (optional) A list of domain IDs to consider
+  repeated int32 excludedDomainIds = 11;
+
+  string searchSetIdentifier = 12; // (optional) A named set of domains to consider
+  string humanQuery = 13;          // The search query as the user entered it
+  RpcQueryLimits queryLimits = 14;
+  int64 afterId = 15;
+
+  string langIsoCode = 20;
+}
+
 /* Index service query request */
 message RpcIndexQuery {
   RpcQueryTerms terms = 1;
@@ -120,13 +137,14 @@ message RpcIndexQuery {
   repeated int32 priorityDomainIds = 16;
   repeated float priorityDomainIdsWeights = 17;
 
-  enum NSFW_FILTER_TIER {
-    NONE = 0;
-    DANGER = 1;
-    PORN_AND_GAMBLING = 2;
-  };
+
 }
 
+enum NSFW_FILTER_TIER {
+  NONE = 0;
+  DANGER = 1;
+  PORN_AND_GAMBLING = 2;
+};
 
 /* A tagged union encoding some limit on a field */
 message RpcSpecLimit {

--- a/code/functions/search-query/api/src/main/protobuf/query-api.proto
+++ b/code/functions/search-query/api/src/main/protobuf/query-api.proto
@@ -6,6 +6,7 @@ option java_multiple_files=true;
 
 service QueryApi {
   rpc query(RpcQsQuery) returns (RpcQsResponse) {}
+  rpc unrankedQuery(RpcQsUnrankedQuery) returns (RpcQsUnrankedResponse) {}
   rpc invalidateFilterCache(RpcQsInvalidateFilter) returns (Empty) {}
 }
 
@@ -18,6 +19,9 @@ message Empty {}
 
 message RpcIndexQueryResponse {
   repeated RpcDecoratedResultItem results = 2;
+
+  int64 lastResultId = 3;
+  bool finished = 4;
 }
 
 
@@ -35,12 +39,21 @@ message RpcQsQuery {
   NSFW_FILTER_TIER nsfwFilterTier = 5;
   RpcQueryLimits queryLimits = 6;
   RpcQsQueryPagination pagination = 7;
+}
 
-  enum NSFW_FILTER_TIER {
-    NONE = 0;
-    DANGER = 1;
-    PORN_AND_GAMBLING = 2;
-  };
+
+message RpcQsUnrankedQuery {
+  repeated string termsRequired = 1;
+  repeated string termsExcluded = 2;
+
+  repeated int32 requiredDomainIds = 10;     // (optional) A list of domain IDs to consider
+  repeated int32 excludedDomainIds = 11;
+
+  RpcQueryLimits queryLimits = 14;
+
+  string encodedCursor = 15;
+
+  string langIsoCode = 20;
 }
 
 message RpcQsFilterIdentifier {
@@ -81,6 +94,11 @@ message RpcQsResponse {
   RpcQsResultPagination pagination = 6;
 }
 
+message RpcQsUnrankedResponse {
+  repeated RpcDecoratedResultItem results = 1;
+  string encodedCursor = 15;
+}
+
 message RpcQsQueryPagination {
   int32 page = 1;
   int32 pageSize = 2;
@@ -108,8 +126,6 @@ message RpcIndexUnrankedQuery {
   repeated int32 requiredDomainIds = 10;     // (optional) A list of domain IDs to consider
   repeated int32 excludedDomainIds = 11;
 
-  string searchSetIdentifier = 12; // (optional) A named set of domains to consider
-  string humanQuery = 13;          // The search query as the user entered it
   RpcQueryLimits queryLimits = 14;
   int64 afterId = 15;
 
@@ -136,8 +152,6 @@ message RpcIndexQuery {
   repeated int32 excludedDomainIds = 15;
   repeated int32 priorityDomainIds = 16;
   repeated float priorityDomainIdsWeights = 17;
-
-
 }
 
 enum NSFW_FILTER_TIER {

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
@@ -42,7 +42,12 @@ public class QueryGRPCService
             .classicLinearUpperBounds(0.05, 0.05, 15)
             .help("QS-side query time (GRPC endpoint)")
             .register();
-
+    private static final Histogram wmsa_qs_query_unranked_time_grpc = Histogram.builder()
+            .name("wmsa_qs_query_unranked_time_grpc")
+            .labelNames("timeout", "count")
+            .classicLinearUpperBounds(0.05, 0.05, 15)
+            .help("QS-side unranked query time (GRPC endpoint)")
+            .register();
     private static final Counter wmsa_qs_queries_shed = Counter.builder()
             .name("wmsa_qs_queries_shed")
             .help("Queries rejected before query construction due to client saturation")
@@ -146,43 +151,42 @@ public class QueryGRPCService
                 return;
             }
 
-            wmsa_qs_query_time_grpc
-                    .labelValues(Integer.toString(request.getQueryLimits().getTimeoutMs()),
-                            Integer.toString(request.getQueryLimits().getResultsTotal()))
-                    .time(() -> {
+            IndexClient.Pagination pagination = new IndexClient.Pagination(request.getPagination());
 
-                        IndexClient.Pagination pagination = new IndexClient.Pagination(request.getPagination());
+            Optional<ProcessedQuery> maybeQuery = createQuery(request);
+            if (maybeQuery.isEmpty()) {
+                responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
+                return;
+            }
 
-                        Optional<ProcessedQuery> maybeQuery = createQuery(request);
-                        if (maybeQuery.isEmpty()) {
-                            responseObserver.onError(Status.NOT_FOUND.asRuntimeException());
-                            return;
-                        }
+            ProcessedQuery query = maybeQuery.get();
 
-                        ProcessedQuery query = maybeQuery.get();
+            // Execute the query on the index partitions
+            IndexClient.AggregateQueryResponse response =
+                    wmsa_qs_query_time_grpc
+                            .labelValues(Integer.toString(request.getQueryLimits().getTimeoutMs()),
+                                    Integer.toString(request.getQueryLimits().getResultsTotal()))
+                            .time(() -> indexClient.executeQueries(query.indexQuery, pagination));
 
-                        // Execute the query on the index partitions
-                        IndexClient.AggregateQueryResponse response = indexClient.executeQueries(query.indexQuery, pagination);
+            // Convert results to response and send it back
+            var responseBuilder = RpcQsResponse.newBuilder()
+                    .addAllResults(response.results())
+                    .setPagination(
+                            RpcQsResultPagination.newBuilder()
+                                    .setPage(pagination.page())
+                                    .setPageSize(pagination.pageSize())
+                                    .setTotalResults(response.totalResults())
+                    )
+                    .setSpecs(query.indexQuery)
+                    .addAllSearchTermsHuman(query.searchTermsHuman);
 
-                        // Convert results to response and send it back
-                        var responseBuilder = RpcQsResponse.newBuilder()
-                                .addAllResults(response.results())
-                                .setPagination(
-                                        RpcQsResultPagination.newBuilder()
-                                                .setPage(pagination.page())
-                                                .setPageSize(pagination.pageSize())
-                                                .setTotalResults(response.totalResults())
-                                )
-                                .setSpecs(query.indexQuery)
-                                .addAllSearchTermsHuman(query.searchTermsHuman);
+            if (query.domain != null) {
+                responseBuilder.setDomain(query.domain);
+            }
 
-                        if (query.domain != null) {
-                            responseBuilder.setDomain(query.domain);
-                        }
+            responseObserver.onNext(responseBuilder.build());
+            responseObserver.onCompleted();
 
-                        responseObserver.onNext(responseBuilder.build());
-                        responseObserver.onCompleted();
-                    });
         } catch (StatusRuntimeException e) {
             responseObserver.onError(e);
         } catch (Exception e) {
@@ -205,6 +209,7 @@ public class QueryGRPCService
                     .asRuntimeException());
             return;
         }
+
 
 
         RpcIndexUnrankedQuery unrankedQueryPrototype = RpcIndexUnrankedQuery.newBuilder()
@@ -232,7 +237,9 @@ public class QueryGRPCService
         }
 
         try {
-            var response = indexClient.executeQueries(unrankedQueryPrototype, cursor);
+            var response = wmsa_qs_query_unranked_time_grpc
+                    .labelValues(Integer.toString(request.getQueryLimits().getTimeoutMs()), Integer.toString(request.getQueryLimits().getResultsTotal()))
+                    .time(() -> indexClient.executeQueries(unrankedQueryPrototype, cursor));
 
             responseObserver.onNext(RpcQsUnrankedResponse.newBuilder()
                     .setEncodedCursor(response.cursor().encode())

--- a/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
+++ b/code/functions/search-query/java/nu/marginalia/functions/searchquery/QueryGRPCService.java
@@ -16,6 +16,7 @@ import nu.marginalia.api.searchquery.model.query.NsfwFilterTier;
 import nu.marginalia.api.searchquery.model.query.ProcessedQuery;
 import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
 import nu.marginalia.functions.searchquery.searchfilter.SearchFilterStore;
+import nu.marginalia.index.UnrankedCursor;
 import nu.marginalia.index.api.IndexClient;
 import nu.marginalia.nsfw.domain.NsfwDomainFilter;
 import nu.marginalia.functions.searchquery.searchfilter.SearchFilterCache;
@@ -187,6 +188,65 @@ public class QueryGRPCService
         } catch (Exception e) {
             logger.error("Exception", e);
             responseObserver.onError(Status.INTERNAL.withCause(e).asRuntimeException());
+        }
+    }
+
+    @Override
+    public void unrankedQuery(RpcQsUnrankedQuery request, StreamObserver<RpcQsUnrankedResponse> responseObserver) {
+        if (Context.current().isCancelled()) {
+            responseObserver.onError(Status.CANCELLED.asRuntimeException());
+            return;
+        }
+
+        if (!indexClient.hasAvailableCapacity()) {
+            wmsa_qs_queries_shed.inc();
+            responseObserver.onError(Status.RESOURCE_EXHAUSTED
+                    .withDescription("Too many concurrent queries in flight")
+                    .asRuntimeException());
+            return;
+        }
+
+
+        RpcIndexUnrankedQuery unrankedQueryPrototype = RpcIndexUnrankedQuery.newBuilder()
+                .addAllTermsExcluded(request.getTermsExcludedList())
+                .addAllTermsRequired(request.getTermsRequiredList())
+                .addAllRequiredDomainIds(request.getRequiredDomainIdsList())
+                .addAllExcludedDomainIds(request.getExcludedDomainIdsList())
+                .setQueryLimits(request.getQueryLimits())
+                .setLangIsoCode(request.getLangIsoCode())
+                .build();
+
+        UnrankedCursor cursor;
+
+        try {
+            cursor = UnrankedCursor.parse(request.getEncodedCursor());
+        } catch (NumberFormatException e) {
+            responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Invalid cursor").asRuntimeException());
+            return;
+        }
+
+        if (cursor instanceof UnrankedCursor.Terminal) {
+            responseObserver.onNext(RpcQsUnrankedResponse.newBuilder().setEncodedCursor(request.getEncodedCursor()).build());
+            responseObserver.onCompleted();
+            return;
+        }
+
+        try {
+            var response = indexClient.executeQueries(unrankedQueryPrototype, cursor);
+
+            responseObserver.onNext(RpcQsUnrankedResponse.newBuilder()
+                    .setEncodedCursor(response.cursor().encode())
+                    .addAllResults(response.results())
+                    .build());
+
+            responseObserver.onCompleted();
+        }
+        catch (StatusRuntimeException ex) {
+            responseObserver.onError(ex);
+        }
+        catch (Exception ex) {
+            logger.error("Exception", ex);
+            responseObserver.onError(Status.INTERNAL.withCause(ex).asRuntimeException());
         }
     }
 

--- a/code/index/api/build.gradle
+++ b/code/index/api/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     }
     implementation libs.bundles.protobuf
     implementation libs.fastutil
+    implementation libs.commons.lang3
     implementation libs.javax.annotation
     implementation libs.bundles.gson
     implementation libs.guava

--- a/code/index/api/java/nu/marginalia/index/UnrankedCursor.java
+++ b/code/index/api/java/nu/marginalia/index/UnrankedCursor.java
@@ -1,0 +1,69 @@
+package nu.marginalia.index;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.StringJoiner;
+
+public sealed interface UnrankedCursor {
+
+    public String encode();
+
+    public static UnrankedCursor forPositions(IntList nodes, LongList indexes) {
+        if (nodes.isEmpty())
+            return new Terminal();
+        return new Partial(nodes, indexes);
+    }
+
+    static UnrankedCursor parse(String cursor) throws NumberFormatException {
+        if (StringUtils.isEmpty(cursor))
+            return new Uninitialized();
+
+        if ("FIN".equals(cursor))
+            return new Terminal();
+
+        IntList nodes = new IntArrayList();
+        LongList positions = new LongArrayList();
+
+        String[] parts = StringUtils.split(cursor, '.');
+
+        for (var part: parts) {
+            int node = Integer.parseInt(part.substring(0, 1), 36);
+            long position = Long.parseUnsignedLong(part.substring(1), 36);
+
+            nodes.add(node);
+            positions.add(position);
+        }
+
+        return new Partial(nodes, positions);
+    }
+
+    static String encodeLong(long value) {
+        return Long.toUnsignedString(value, 36);
+    }
+
+    record Uninitialized() implements UnrankedCursor {
+        public String encode() {
+            return "";
+        }
+    }
+
+    record Terminal() implements UnrankedCursor {
+        public String encode() {
+            return "FIN";
+        }
+    }
+
+    record Partial(IntList nodes, LongList positions) implements UnrankedCursor {
+        public String encode() {
+            StringJoiner joiner = new StringJoiner(".");
+            for (int i = 0; i < nodes.size(); i++) {
+                joiner.add(Integer.toString(nodes.getInt(i), 36) + Long.toUnsignedString(positions.getLong(i), 36));
+            }
+            return joiner.toString();
+        }
+    }
+}

--- a/code/index/api/java/nu/marginalia/index/api/IndexClient.java
+++ b/code/index/api/java/nu/marginalia/index/api/IndexClient.java
@@ -10,8 +10,12 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.core.metrics.Gauge;
+import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import nu.marginalia.api.searchquery.*;
 import nu.marginalia.db.DomainBlacklistImpl;
+import nu.marginalia.index.UnrankedCursor;
 import nu.marginalia.model.id.UrlIdCodec;
 import nu.marginalia.nsfw.document.NsfwDocumentFilter;
 import nu.marginalia.nsfw.domain.NsfwDomainFilter;
@@ -23,18 +27,18 @@ import nu.marginalia.service.discovery.property.ServicePartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.Consumer;
 
 @Singleton
 public class IndexClient {
     private static final Logger logger = LoggerFactory.getLogger(IndexClient.class);
     private final List<GrpcSingleNodeChannelPool<IndexApiGrpc.IndexApiFutureStub>> channelPools;
+    private final Int2ObjectMap<GrpcSingleNodeChannelPool<IndexApiGrpc.IndexApiFutureStub>> poolById = new Int2ObjectOpenHashMap<>();
     private final DomainBlacklistImpl blacklist;
     private final NsfwDomainFilter nsfwDomainFilter;
     private final NsfwDocumentFilter nsfwDocumentFilter;
@@ -81,7 +85,9 @@ public class IndexClient {
         channelPools = new ArrayList<>();
 
         for (int node: nodeConfigurationWatcher.getQueryNodes()) {
-            channelPools.add(channelPoolFactory.createSingle(ServiceKey.forGrpcApi(IndexApiGrpc.class, ServicePartition.partition(node)), IndexApiGrpc::newFutureStub));
+            var pool = channelPoolFactory.createSingle(ServiceKey.forGrpcApi(IndexApiGrpc.class, ServicePartition.partition(node)), IndexApiGrpc::newFutureStub);
+            channelPools.add(pool);
+            poolById.put(node, pool);
         }
 
         this.blacklist = blacklist;
@@ -90,6 +96,167 @@ public class IndexClient {
 
     private static final Comparator<RpcDecoratedResultItem> comparator =
             Comparator.comparing(RpcDecoratedResultItem::getRankingScore);
+
+    public record AggreagateUnrankedQueryResponse(List<RpcDecoratedResultItem> results,
+                                                  UnrankedCursor cursor) {
+
+    }
+
+    public AggreagateUnrankedQueryResponse executeQueries(RpcIndexUnrankedQuery unrankedQueryPrototype,
+                                                          UnrankedCursor cursor)
+    {
+        boolean acquired = false;
+        try {
+            if (Context.current().isCancelled()) {
+                wmsa_index_query_cancelled.inc();
+                throw Status.CANCELLED.withDescription("Request abandoned by caller").asRuntimeException();
+            }
+
+            long queueBudgetMs = clampToRequestDeadline(unrankedQueryPrototype.getQueryLimits().getTimeoutMs() / 2, 0);
+
+            acquired = queryThrottle.tryAcquire(Math.max(0, queueBudgetMs), TimeUnit.MILLISECONDS);
+            if (!acquired) {
+                wmsa_index_query_rejected.inc();
+                throw Status.RESOURCE_EXHAUSTED
+                        .withDescription("Too many concurrent index queries in flight")
+                        .asRuntimeException();
+            }
+            wmsa_index_query_inflight.inc();
+
+            return executeQueriesInternal(unrankedQueryPrototype, cursor);
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw Status.CANCELLED.withDescription("Interrupted awaiting query slot").asRuntimeException();
+        }
+        finally {
+            if (acquired) {
+                wmsa_index_query_inflight.dec();
+                queryThrottle.release();
+            }
+        }
+    }
+
+
+    private AggreagateUnrankedQueryResponse executeQueriesInternal(RpcIndexUnrankedQuery unrankedQueryPrototype,
+                                                                   UnrankedCursor packedCursor) {
+
+        long timeoutMs = unrankedQueryPrototype.getQueryLimits().getTimeoutMs();
+        long fanOutBudgetMs = clampToRequestDeadline(2 * timeoutMs, 50);
+
+        if (fanOutBudgetMs <= 0 || Context.current().isCancelled()) {
+            wmsa_index_query_cancelled.inc();
+            throw Status.CANCELLED.withDescription("Request abandoned by caller").asRuntimeException();
+        }
+
+        Instant bailInstant = Instant.now().plusMillis(fanOutBudgetMs);
+
+        Map<Integer, List<RpcDecoratedResultItem>> results = new LinkedHashMap<>(channelPools.size());
+        Map<Integer, Map.Entry<GrpcSingleNodeChannelPool.ConnectionHolder, ListenableFuture<RpcIndexQueryResponse>>> futures
+                = new LinkedHashMap<>(channelPools.size());
+
+        // Decode the cursor into a map of node -> position
+        Int2LongArrayMap cursor = new Int2LongArrayMap();
+        switch (packedCursor) {
+            case UnrankedCursor.Terminal() -> {
+                throw new IllegalArgumentException("Terminal cursor not supported");
+            }
+            case UnrankedCursor.Uninitialized() -> {
+                for (int node: poolById.keySet()) {
+                    cursor.put(node, 0);
+                }
+            }
+            case UnrankedCursor.Partial(IntList nodes, LongList positions) -> {
+                for (int i = 0; i < nodes.size(); i++) {
+                    int node = nodes.getInt(i);
+                    long position = positions.getLong(i);
+                    cursor.put(node, position);
+                }
+            }
+        }
+
+        // Execute the queries on each node
+        for (var entry : cursor.int2LongEntrySet()) {
+            var pool = poolById.get(entry.getIntKey());
+            if (pool == null) {
+                logger.warn("Node {} found in cursor, but not in channel pool", entry.getIntKey());
+                continue;
+            }
+
+            int node = entry.getIntKey();
+            long afterId = entry.getLongValue();
+
+            var holder = pool.getBestConnectionHolder();
+            var channel = holder.map(GrpcSingleNodeChannelPool.ConnectionHolder::get);
+
+            if (channel.isEmpty())
+                continue;
+
+            var fut = IndexApiGrpc.newFutureStub(channel.get())
+                    .withExecutor(executor)
+                    .withDeadlineAfter(Duration.ofMillis(Math.min((long) (1.5 * timeoutMs), fanOutBudgetMs)))
+                    .unrankedQuery(RpcIndexUnrankedQuery.newBuilder(unrankedQueryPrototype).setAfterId(afterId).build());
+
+            futures.put(node, Map.entry(holder.get(), fut));
+        }
+
+        IntSet failedNodes = new IntOpenHashSet();
+        IntSet finishedNodes = new IntOpenHashSet();
+        Int2LongArrayMap lastIds = new Int2LongArrayMap();
+
+        // Handle the results of the queries
+        for (var entry: futures.entrySet()) {
+            int node = entry.getKey();
+
+            var holderAndFuture = entry.getValue();
+            var holder = holderAndFuture.getKey();
+            var future = holderAndFuture.getValue();
+
+            boolean wasSuccess = handleResults(holder, bailInstant, future, (res) -> {
+                results.put(node, res.getResultsList());
+
+                if (res.getFinished()) {
+                    finishedNodes.add(node);
+                }
+                else {
+                    lastIds.put(node, res.getLastResultId());
+                }
+            });
+
+            if (!wasSuccess) {
+                failedNodes.add(node);
+            }
+        }
+
+        // Construct a new cursor
+        IntArrayList newCursorNodes = new IntArrayList();
+        LongArrayList newCursorPositions = new LongArrayList();
+
+        for (var entry: results.entrySet()) {
+            int node = entry.getKey();
+            var resultsList = entry.getValue();
+
+            if (!finishedNodes.contains(node)) {
+                newCursorNodes.add(node);
+                newCursorPositions.add(lastIds.get(node));
+            }
+        }
+
+        for (var failedNode: failedNodes) {
+            newCursorNodes.add(failedNode);
+            newCursorPositions.add(cursor.get(failedNode));
+        }
+
+        UnrankedCursor newCursor = UnrankedCursor.forPositions(newCursorNodes, newCursorPositions);
+
+        // Grab the results
+        List<RpcDecoratedResultItem> ret = new ArrayList<>();
+        for (var res: results.values()) {
+            ret.addAll(res);
+        }
+
+        return new AggreagateUnrankedQueryResponse(ret, newCursor);
+    }
 
     public record Pagination(int page, int pageSize) {
         public Pagination(RpcQsQueryPagination pagination) {
@@ -167,76 +334,25 @@ public class IndexClient {
                 = new ArrayList<>(channelPools.size());
 
         for (var pool: channelPools) {
-            GrpcSingleNodeChannelPool.ConnectionHolder holder = null;
-            ManagedChannel channel = null;
+            var holder = pool.getBestConnectionHolder();
+            var channel = holder.map(GrpcSingleNodeChannelPool.ConnectionHolder::get);
 
-            for (var h : pool.getConnectionHolders()) {
-                if (h.hasErrorSince(Duration.ofSeconds(5)))
-                    continue;
-                holder = h;
-                channel = h.get();
-                break;
-            }
-
-            if (null == channel)
+            if (channel.isEmpty())
                 continue;
 
-            var fut = IndexApiGrpc.newFutureStub(channel)
+            var fut = IndexApiGrpc.newFutureStub(channel.get())
                             .withExecutor(executor)
                             .withDeadlineAfter(Duration.ofMillis(Math.min((long) (1.5 * timeoutMs), fanOutBudgetMs)))
                         .query(indexRequest);
 
-            futures.add(Map.entry(holder, fut));
+            futures.add(Map.entry(holder.get(), fut));
         }
 
         for (var holderAndFuture: futures) {
             var holder = holderAndFuture.getKey();
             var future = holderAndFuture.getValue();
-            try {
-                Instant now = Instant.now();
-                if (now.isAfter(bailInstant)) {
-                    if (future.state() == Future.State.SUCCESS) {
-                        results.addAll(future.resultNow().getResultsList());
-                    }
-                    else {
-                        future.cancel(true);
-                    }
-                }
-                else {
-                    results.addAll(future.get(Duration.between(now, bailInstant).toMillis(), TimeUnit.MILLISECONDS).getResultsList());
-                }
-            }
-            catch (ExecutionException ex) {
-                if (ex.getCause() instanceof StatusRuntimeException sre) {
-                    switch (sre.getStatus().getCode()) {
-                        case DEADLINE_EXCEEDED -> logger.warn("Timeout: {}", sre.getMessage());
-                        case UNAVAILABLE -> {
-                            logger.warn("Unavailable: {}", sre.getMessage());
-                            holder.flagError();
-                        }
-                        case INTERNAL -> logger.warn("Internal Error in index: {}", sre);
-                        case RESOURCE_EXHAUSTED -> {
-                            logger.warn("Index partition overloaded: {}", sre.getMessage());
-                            wmsa_index_query_node_overloaded.inc();
-                            holder.flagError();
-                        }
-                        case CANCELLED -> wmsa_index_query_cancelled.inc();
-                        default -> logger.error("Error while fetching results", ex.getCause());
-                    }
-                }
-                else {
-                    holder.flagError();
-                    logger.error("Error while fetching results", ex.getCause());
-                }
-            }
-            catch (TimeoutException e) {
-                future.cancel(true);
-                logger.error("Index request timeout");
-            }
-            catch (Exception e) {
-                future.cancel(true);
-                logger.error("Error while fetching results", e);
-            }
+            handleResults(holder, bailInstant, future,
+                    (res) -> results.addAll(res.getResultsList()));
         }
 
         results.removeIf(item -> isExcluded(item, filterTier));
@@ -254,6 +370,69 @@ public class IndexClient {
 
         return new AggregateQueryResponse(ret, pagination.page(), totalNumResults);
     }
+
+
+    /** Handle the result of a query on an index partition.
+     *
+     * @return true if the result was handled successfully, false if the query was not handled due to timeout or error.
+     * */
+    private <T> boolean handleResults(GrpcSingleNodeChannelPool.ConnectionHolder holder,
+                                   Instant bailInstant,
+                                   ListenableFuture<T> future,
+                                   Consumer<T> onSuccess)
+    {
+        try {
+            Instant now = Instant.now();
+            if (now.isAfter(bailInstant)) {
+                if (future.state() == Future.State.SUCCESS) {
+                    onSuccess.accept(future.resultNow());
+                    return true;
+                }
+                else {
+                    future.cancel(true);
+                }
+            }
+            else {
+                onSuccess.accept(future.get(Duration.between(now, bailInstant).toMillis(), TimeUnit.MILLISECONDS));
+                return true;
+            }
+        }
+        catch (ExecutionException ex) {
+            if (ex.getCause() instanceof StatusRuntimeException sre) {
+                switch (sre.getStatus().getCode()) {
+                    case DEADLINE_EXCEEDED -> logger.warn("Timeout: {}", sre.getMessage());
+                    case UNAVAILABLE -> {
+                        logger.warn("Unavailable: {}", sre.getMessage());
+                        holder.flagError();
+                    }
+                    case INTERNAL -> logger.warn("Internal Error in index: {}", sre);
+                    case RESOURCE_EXHAUSTED -> {
+                        logger.warn("Index partition overloaded: {}", sre.getMessage());
+                        wmsa_index_query_node_overloaded.inc();
+                        holder.flagError();
+                    }
+                    case CANCELLED -> wmsa_index_query_cancelled.inc();
+                    default -> logger.error("Error while fetching results", ex.getCause());
+                }
+            }
+            else {
+                holder.flagError();
+                logger.error("Error while fetching results", ex.getCause());
+            }
+        }
+        catch (TimeoutException e) {
+            future.cancel(true);
+            logger.error("Index request timeout");
+        }
+        catch (Exception e) {
+            future.cancel(true);
+            logger.error("Error while fetching results", e);
+        }
+
+        return false;
+    }
+
+
 
     static String[] tierNames = {
             "OFF",

--- a/code/index/api/test/nu/marginalia/index/UnrankedCursorTest.java
+++ b/code/index/api/test/nu/marginalia/index/UnrankedCursorTest.java
@@ -1,0 +1,45 @@
+package nu.marginalia.index;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UnrankedCursorTest {
+
+    @Test
+    public void testEncodeDecodePartial() {
+        IntList nodes = IntList.of(1, 5, 3);
+        LongList positions = LongList.of(30L, 0x1000F000A000E000L, -3000L);
+
+        String encoded = new UnrankedCursor.Partial(nodes, positions).encode();
+        System.out.println(encoded);
+
+        var parsed = UnrankedCursor.parse(encoded);
+        System.out.println(parsed);
+
+        Assertions.assertTrue(parsed instanceof UnrankedCursor.Partial);
+
+        UnrankedCursor.Partial partial = (UnrankedCursor.Partial) parsed;
+
+        Assertions.assertEquals(nodes, partial.nodes());
+        Assertions.assertEquals(positions, partial.positions());
+    }
+
+    @Test
+    public void testEncodeDecodeTerminal() {
+        String encoded = new UnrankedCursor.Terminal().encode();
+        System.out.println(encoded);
+        Assertions.assertEquals("FIN", encoded);
+        Assertions.assertTrue(UnrankedCursor.parse(encoded) instanceof UnrankedCursor.Terminal);
+    }
+
+    @Test
+    public void testEncodeDecodeUninitialized() {
+        String encoded = new UnrankedCursor.Uninitialized().encode();
+        System.out.println(encoded);
+        Assertions.assertEquals("", encoded);
+        Assertions.assertTrue(UnrankedCursor.parse(encoded) instanceof UnrankedCursor.Uninitialized);
+    }
+
+}

--- a/code/index/java/nu/marginalia/index/CombinedIndexReader.java
+++ b/code/index/java/nu/marginalia/index/CombinedIndexReader.java
@@ -258,15 +258,6 @@ public class CombinedIndexReader {
         if (!context.mandatoryDomainIds.isEmpty())
             head.requiringDomains(getDocumentRangesForDomains(context.mandatoryDomainIds));
 
-        if (!context.termIdsDomain.isEmpty()) {
-            List<String> domainTerms = new ArrayList<>(context.termIdsDomain.size());
-            for (long id : context.termIdsDomain) {
-                domainTerms.add(termIdToString.getOrDefault(id, "???"));
-            }
-
-            head.addInclusionFilter(hasAnyWordFull(languageContext, domainTerms, context.termIdsDomain, context.budget));
-        }
-
         for (long termId : context.termIdsRequire) {
             head = head.also(termIdToString.getOrDefault(termId, "???"), termId, context.budget);
         }

--- a/code/index/java/nu/marginalia/index/CombinedIndexReader.java
+++ b/code/index/java/nu/marginalia/index/CombinedIndexReader.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
-import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -203,6 +202,82 @@ public class CombinedIndexReader {
                 .toList();
     }
 
+
+
+    public List<IndexQuery> createUnrankedQueries(UnrankedSearchContext context) {
+
+        if (!isLoaded()) {
+            logger.warn("Index reader not ready");
+            return Collections.emptyList();
+        }
+
+        final IndexLanguageContext languageContext = context.languageContext;
+
+        final long[] termSortOrder = context.sortedDistinctIncludes((a,b) -> Long.compare(
+                numHits(languageContext, a),
+                numHits(languageContext, b)
+        ));
+
+        LongList searchTerms = new LongArrayList(context.termIdsRequireUnique);
+
+        // Sort in order of size in the index
+        searchTerms.sort((a, b) -> {
+            for (long l : termSortOrder) {
+                if (l == a)
+                    return -1;
+                if (l == b)
+                    return 1;
+            }
+            return 0;
+        });
+
+        Long2ObjectOpenHashMap<String> termIdToString = context.termIdToString;
+
+        IndexQueryBuilder head;
+
+        long firstTermId = searchTerms.getLong(0);
+        String firstTerm = termIdToString.getOrDefault(firstTermId, "???");
+
+        if (context.afterCombinedDocId != 0)
+            head = findFullWord(languageContext,
+                    getDocumentRangesAfterDocId(context.afterCombinedDocId),
+                    firstTerm,
+                    firstTermId);
+        else
+            head = findFullWord(languageContext,
+                    null,
+                    firstTerm,
+                    firstTermId);
+
+        if (head.isNoOp()) {
+            return List.of();
+        }
+
+        if (!context.excludedDomainIds.isEmpty())
+            head.rejectingDomains(getDocumentRangesForDomains(context.excludedDomainIds));
+        if (!context.mandatoryDomainIds.isEmpty())
+            head.requiringDomains(getDocumentRangesForDomains(context.mandatoryDomainIds));
+
+        if (!context.termIdsDomain.isEmpty()) {
+            List<String> domainTerms = new ArrayList<>(context.termIdsDomain.size());
+            for (long id : context.termIdsDomain) {
+                domainTerms.add(termIdToString.getOrDefault(id, "???"));
+            }
+
+            head.addInclusionFilter(hasAnyWordFull(languageContext, domainTerms, context.termIdsDomain, context.budget));
+        }
+
+        for (long termId : context.termIdsRequire) {
+            head = head.also(termIdToString.getOrDefault(termId, "???"), termId, context.budget);
+        }
+
+        for (long termId : context.termIdsExcludes) {
+            head = head.not(termIdToString.getOrDefault(termId, "???"), termId, context.budget);
+        }
+
+        return List.of(head.build());
+    }
+
     private Predicate<LongSet> containsAll(long[] permitted) {
         LongSet permittedTerms = new LongOpenHashSet(permitted);
         return permittedTerms::containsAll;
@@ -265,6 +340,14 @@ public class CombinedIndexReader {
         return new SkipListValueRanges(rangesStarts, rangesEnds);
     }
 
+    private SkipListValueRanges getDocumentRangesAfterDocId(long combinedDocId) {
+
+        long start = combinedDocId + 1;
+        long end = Long.MAX_VALUE;
+
+        return new SkipListValueRanges(new long[] { start }, new long[] { end });
+    }
+
     /** Creates a parameter matching filter step for the provided parameters */
     public QueryFilterStepIf filterForParams(QueryParams params) {
         return new ParamMatchingQueryFilter(params, forwardIndexReader);
@@ -283,8 +366,8 @@ public class CombinedIndexReader {
     }
 
     /** Retrieves the document metadata for the specified document */
-    public long getDocumentMetadata(long docId) {
-        return forwardIndexReader.getDocMeta(docId);
+    public long getDocumentMetadata(long combinedDocId) {
+        return forwardIndexReader.getDocMeta(combinedDocId);
     }
 
     /** Returns the total number of documents in the index */
@@ -293,8 +376,8 @@ public class CombinedIndexReader {
     }
 
     /** Retrieves the HTML features for the specified document */
-    public int getHtmlFeatures(long docId) {
-        return forwardIndexReader.getHtmlFeatures(docId);
+    public int getHtmlFeatures(long combinedDocId) {
+        return forwardIndexReader.getHtmlFeatures(combinedDocId);
     }
 
     /** Retrieves the HTML features for the specified document */

--- a/code/index/java/nu/marginalia/index/IndexGrpcService.java
+++ b/code/index/java/nu/marginalia/index/IndexGrpcService.java
@@ -3,15 +3,14 @@ package nu.marginalia.index;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.core.metrics.Histogram;
-import nu.marginalia.api.searchquery.IndexApiGrpc;
-import nu.marginalia.api.searchquery.RpcDecoratedResultItem;
-import nu.marginalia.api.searchquery.RpcIndexQuery;
-import nu.marginalia.api.searchquery.RpcIndexQueryResponse;
+import nu.marginalia.api.searchquery.*;
 import nu.marginalia.index.model.SearchContext;
+import nu.marginalia.index.model.UnrankedSearchContext;
 import nu.marginalia.index.results.IndexResultRankingService;
 import nu.marginalia.index.searchset.SearchSet;
 import nu.marginalia.index.searchset.SearchSetsService;
@@ -99,7 +98,7 @@ public class IndexGrpcService
 
         try {
             long endTime = System.currentTimeMillis() + request.getQueryLimits().getTimeoutMs();
-            KeywordHasher hasher = findHasher(request);
+            KeywordHasher hasher = findHasher(request.getLangIsoCode());
 
             List<RpcDecoratedResultItem> results = wmsa_query_time
                     .labelValues(nodeName, "GRPC")
@@ -115,7 +114,7 @@ public class IndexGrpcService
 
                             if (!set.imposesConstraint()
                                 && "en".equalsIgnoreCase(request.getLangIsoCode())
-                                && !hasSiteTerm(request)
+                                && !hasSiteTerm(request.getTerms())
                             ) {
                                 connectivityView = connectivitySets.getView();
                             }
@@ -163,8 +162,54 @@ public class IndexGrpcService
         }
     }
 
-    private boolean hasSiteTerm(RpcIndexQuery request) {
-        for (var term : request.getTerms().getTermsRequireList()) {
+    @Override
+    public void unrankedQuery(RpcIndexUnrankedQuery request, StreamObserver<RpcIndexQueryResponse> responseObserver) {
+
+        try {
+            KeywordHasher hasher = findHasher(request.getLangIsoCode());
+
+            List<RpcDecoratedResultItem> results = null;
+
+            // Perform the search
+            try (StatefulIndex.IndexReference indexReference = statefulIndex.get()) {
+                if (!indexReference.isAvailable()) {
+                    throw Status.FAILED_PRECONDITION.withDescription("Index not available").asRuntimeException();
+                }
+
+                CombinedIndexReader index = indexReference.get();
+
+                UnrankedSearchContext rankingContext = UnrankedSearchContext.create(index, hasher, request);
+
+                if (rankingContext.termIdsRequireUnique.size() == 0)
+                    throw Status.INVALID_ARGUMENT.withDescription("Received invalid request with no term ids")
+                            .asRuntimeException();
+
+                if (rankingContext.limitTotal > 1_000_000)
+                    throw Status.INVALID_ARGUMENT.withDescription("Received invalid request with dangerous limitTotal")
+                            .asRuntimeException();
+
+                IndexUnrankedQueryExecution queryExecution =
+                        new IndexUnrankedQueryExecution(index, documentDbReader, rankingService, rankingContext, nodeId);
+                results = queryExecution.run();
+            }
+
+            responseObserver.onNext(RpcIndexQueryResponse.newBuilder()
+                    .addAllResults(results)
+                    .build());
+
+            responseObserver.onCompleted();
+        }
+        catch (StatusRuntimeException ex) {
+            responseObserver.onError(ex);
+        }
+        catch (Exception ex) {
+            logger.error("Error in handling request", ex);
+            responseObserver.onError(Status.INTERNAL.withCause(ex).asRuntimeException());
+        }
+    }
+
+    private boolean hasSiteTerm(RpcQueryTerms terms) {
+        for (var term : terms.getTermsRequireList()) {
             if (term.startsWith("site:"))
                 return true;
         }
@@ -174,8 +219,8 @@ public class IndexGrpcService
     /** Keywords are translated to a numeric format via a 64 bit hash algorithm,
      * which varies depends on the language.
      */
-    private KeywordHasher findHasher(RpcIndexQuery request) {
-        KeywordHasher hasher = keywordHasherByLangIso.get(request.getLangIsoCode());
+    private KeywordHasher findHasher(String isoLangCode) {
+        KeywordHasher hasher = keywordHasherByLangIso.get(isoLangCode);
         if (hasher != null)
             return hasher;
 
@@ -185,7 +230,6 @@ public class IndexGrpcService
 
         throw new IllegalStateException("Could not find fallback keyword hasher for iso code 'en'");
     }
-
 
     // exists for test access
     public List<RpcDecoratedResultItem> justQuery(RpcIndexQuery request) {
@@ -217,7 +261,6 @@ public class IndexGrpcService
         String identifier = request.getSearchSetIdentifier();
         return searchSetsService.getSearchSetByName(identifier);
     }
-
 
 }
 

--- a/code/index/java/nu/marginalia/index/IndexGrpcService.java
+++ b/code/index/java/nu/marginalia/index/IndexGrpcService.java
@@ -169,6 +169,8 @@ public class IndexGrpcService
             KeywordHasher hasher = findHasher(request.getLangIsoCode());
 
             List<RpcDecoratedResultItem> results = null;
+            boolean isFinished;
+            long lastId;
 
             // Perform the search
             try (StatefulIndex.IndexReference indexReference = statefulIndex.get()) {
@@ -191,10 +193,15 @@ public class IndexGrpcService
                 IndexUnrankedQueryExecution queryExecution =
                         new IndexUnrankedQueryExecution(index, documentDbReader, rankingService, rankingContext, nodeId);
                 results = queryExecution.run();
+
+                lastId = queryExecution.getLastId();
+                isFinished = queryExecution.isFinished();
             }
 
             responseObserver.onNext(RpcIndexQueryResponse.newBuilder()
                     .addAllResults(results)
+                    .setLastResultId(lastId)
+                    .setFinished(isFinished)
                     .build());
 
             responseObserver.onCompleted();

--- a/code/index/java/nu/marginalia/index/IndexGrpcService.java
+++ b/code/index/java/nu/marginalia/index/IndexGrpcService.java
@@ -175,7 +175,11 @@ public class IndexGrpcService
             // Perform the search
             try (StatefulIndex.IndexReference indexReference = statefulIndex.get()) {
                 if (!indexReference.isAvailable()) {
-                    throw Status.FAILED_PRECONDITION.withDescription("Index not available").asRuntimeException();
+                    responseObserver.onNext(RpcIndexQueryResponse.newBuilder()
+                            .setFinished(true)
+                            .build());
+
+                    responseObserver.onCompleted();
                 }
 
                 CombinedIndexReader index = indexReference.get();

--- a/code/index/java/nu/marginalia/index/IndexQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexQueryExecution.java
@@ -47,8 +47,6 @@ import java.util.concurrent.locks.Lock;
 /** Performs an index query */
 public class IndexQueryExecution {
 
-    private static final Logger logger = LoggerFactory.getLogger(IndexQueryExecution.class);
-
     private static final boolean printDebugSummary = Boolean.getBoolean("index.printDebugSummary");
     private static final boolean disableViabilityPrecheck = Boolean.getBoolean("index.disableViabilityPrecheck");
 
@@ -58,8 +56,6 @@ public class IndexQueryExecution {
     private static final int lookupBatchSize = 512;
 
     private static final ExecutorService threadPool = Executors.newCachedThreadPool();
-
-    private static final Logger log = LoggerFactory.getLogger(IndexQueryExecution.class);
 
     private final DocumentDbReader documentDbReader;
     private final String nodeName;

--- a/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
@@ -1,9 +1,10 @@
 package nu.marginalia.index;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import nu.marginalia.api.searchquery.*;
+import nu.marginalia.api.searchquery.RpcDecoratedResultItem;
+import nu.marginalia.api.searchquery.RpcRawResultItem;
+import nu.marginalia.api.searchquery.RpcResultKeywordScore;
 import nu.marginalia.api.searchquery.model.results.SearchResultItem;
 import nu.marginalia.array.page.LongQueryBuffer;
 import nu.marginalia.index.model.RankableDocument;
@@ -20,10 +21,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 /** Performs an index query */
 public class IndexUnrankedQueryExecution {
@@ -41,10 +38,21 @@ public class IndexUnrankedQueryExecution {
 
     private final int limitTotal;
 
+    private boolean finished = false;
+    private long lastId = 0;
+
+    public boolean isFinished() {
+        return finished;
+    }
+    public long getLastId() {
+        return lastId;
+    }
+
+
     public IndexUnrankedQueryExecution(CombinedIndexReader currentIndex,
                                        DocumentDbReader documentDbReader,
                                        IndexResultRankingService rankingService,
-                                       UnrankedSearchContext rankingContext,
+                                       UnrankedSearchContext searchContext,
                                        int serviceNode)
     {
         this.currentIndex = currentIndex;
@@ -52,10 +60,11 @@ public class IndexUnrankedQueryExecution {
         this.nodeName = Integer.toString(serviceNode);
         this.rankingService = rankingService;
 
-        budget = rankingContext.budget;
-        limitTotal = rankingContext.limitTotal;
+        this.lastId = searchContext.afterCombinedDocId;
+        budget = searchContext.budget;
+        limitTotal = searchContext.limitTotal;
 
-        queries = currentIndex.createUnrankedQueries(rankingContext);
+        queries = currentIndex.createUnrankedQueries(searchContext);
     }
 
     public List<RpcDecoratedResultItem> run() throws InterruptedException, SQLException {
@@ -93,6 +102,8 @@ public class IndexUnrankedQueryExecution {
                         buffer.rejectAndAdvance(); // cheaper than retain fwiw
                     }
                 }
+
+                finished = !buffer.hasMore() && !query.hasMore();
             }
         }
         finally {
@@ -100,6 +111,10 @@ public class IndexUnrankedQueryExecution {
         }
 
         results.sort(Comparator.naturalOrder());
+
+        if (!results.isEmpty()) {
+            lastId = results.getLast().combinedDocumentId;
+        }
 
         Map<Long, DocdbUrlDetail> detailsById = documentDbReader.getUrlDetails(new LongArrayList(seenDocIds));
         ResultConverter converter = new ResultConverter();

--- a/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
@@ -1,0 +1,179 @@
+package nu.marginalia.index;
+
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import nu.marginalia.api.searchquery.*;
+import nu.marginalia.api.searchquery.model.results.SearchResultItem;
+import nu.marginalia.array.page.LongQueryBuffer;
+import nu.marginalia.index.model.RankableDocument;
+import nu.marginalia.index.model.UnrankedSearchContext;
+import nu.marginalia.index.results.IndexResultRankingService;
+import nu.marginalia.index.reverse.query.IndexQuery;
+import nu.marginalia.index.reverse.query.IndexSearchBudget;
+import nu.marginalia.linkdb.docs.DocumentDbReader;
+import nu.marginalia.linkdb.model.DocdbUrlDetail;
+import nu.marginalia.model.id.UrlIdCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/** Performs an index query */
+public class IndexUnrankedQueryExecution {
+
+    private static final Logger logger = LoggerFactory.getLogger(IndexUnrankedQueryExecution.class);
+
+    private final DocumentDbReader documentDbReader;
+    private final String nodeName;
+
+    private final CombinedIndexReader currentIndex;
+    private final IndexResultRankingService rankingService;
+
+    private final List<IndexQuery> queries;
+    private final IndexSearchBudget budget;
+
+    private final int limitTotal;
+
+    public IndexUnrankedQueryExecution(CombinedIndexReader currentIndex,
+                                       DocumentDbReader documentDbReader,
+                                       IndexResultRankingService rankingService,
+                                       UnrankedSearchContext rankingContext,
+                                       int serviceNode)
+    {
+        this.currentIndex = currentIndex;
+        this.documentDbReader = documentDbReader;
+        this.nodeName = Integer.toString(serviceNode);
+        this.rankingService = rankingService;
+
+        budget = rankingContext.budget;
+        limitTotal = rankingContext.limitTotal;
+
+        queries = currentIndex.createUnrankedQueries(rankingContext);
+    }
+
+    public List<RpcDecoratedResultItem> run() throws InterruptedException, SQLException {
+        LongOpenHashSet seenDocIds = new LongOpenHashSet(limitTotal*2);
+        List<RankableDocument> results = new ArrayList<>(limitTotal);
+        List<RpcDecoratedResultItem> ret = new ArrayList<>(limitTotal);
+
+        var buffer = new LongQueryBuffer(limitTotal);
+
+        try {
+            for (IndexQuery query : queries) {
+                if (!budget.hasTimeLeft()) break;
+                if (limitTotal <= seenDocIds.size()) break;
+
+                while (query.hasMore() && budget.hasTimeLeft() && seenDocIds.size() < limitTotal) {
+                    buffer.reset();
+                    query.getMoreResults(buffer);
+
+                    if (buffer.isEmpty()) continue;
+
+                    while (buffer.hasMore() && seenDocIds.size() < limitTotal) {
+                        long nextId = buffer.currentValue();
+
+                        if (seenDocIds.add(UrlIdCodec.removeRank(nextId))) {
+                            var result = new RankableDocument(nextId);
+
+                            result.item = new SearchResultItem(nextId,
+                                    currentIndex.getDocumentMetadata(nextId),
+                                    currentIndex.getHtmlFeatures(nextId),
+                                    0, 0L);
+
+                            results.add(result);
+                        }
+
+                        buffer.rejectAndAdvance(); // cheaper than retain fwiw
+                    }
+                }
+            }
+        }
+        finally {
+            buffer.dispose();
+        }
+
+        results.sort(Comparator.naturalOrder());
+
+        Map<Long, DocdbUrlDetail> detailsById = documentDbReader.getUrlDetails(new LongArrayList(seenDocIds));
+        ResultConverter converter = new ResultConverter();
+
+        for (RankableDocument doc : results) {
+
+            final long id = doc.item.getDocumentId();
+            final DocdbUrlDetail docData = detailsById.get(id);
+
+            if (docData == null)
+                continue;
+
+            int pubDate = currentIndex.getDocPubDate(doc.item.combinedId);
+
+            converter.convert(doc, docData, pubDate).ifPresent(ret::add);
+        }
+
+        return ret;
+    }
+
+
+    private static class ResultConverter {
+        private final LongOpenHashSet seenDocumentHashes = new LongOpenHashSet();
+
+        @Nullable
+        public Optional<RpcDecoratedResultItem> convert(RankableDocument doc,
+                                                 DocdbUrlDetail docData,
+                                                 int pubDate) {
+            SearchResultItem resultItem = doc.item;
+
+            // Filter out duplicates by content
+            if (!seenDocumentHashes.add(docData.dataHash())) {
+                return Optional.empty();
+            }
+
+            var rawItem = RpcRawResultItem.newBuilder();
+
+            rawItem.setCombinedId(resultItem.combinedId);
+            rawItem.setHtmlFeatures(resultItem.htmlFeatures);
+            rawItem.setEncodedDocMetadata(resultItem.encodedDocMetadata);
+            rawItem.setHasPriorityTerms(resultItem.hasPrioTerm);
+
+            for (var score : resultItem.keywordScores) {
+                rawItem.addKeywordScores(
+                        RpcResultKeywordScore.newBuilder()
+                                .setFlags(score.flags)
+                                .setPositions(score.positionCount)
+                                .setKeyword(score.keyword)
+                );
+            }
+
+            var decoratedBuilder = RpcDecoratedResultItem.newBuilder()
+                    .setDataHash(docData.dataHash())
+                    .setDescription(docData.description())
+                    .setFeatures(docData.features())
+                    .setFormat(docData.format())
+                    .setRankingScore(resultItem.getScore())
+                    .setTitle(docData.title())
+                    .setUrl(docData.url().toString())
+                    .setUrlQuality(docData.urlQuality())
+                    .setWordsTotal(docData.wordsTotal())
+                    .setBestPositions(resultItem.getBestPositions())
+                    .setResultsFromDomain(doc.resultsFromDomain)
+                    .setRawItem(rawItem);
+
+            if (docData.pubYear() != null) {
+                decoratedBuilder.setPubYear(docData.pubYear());
+            }
+            decoratedBuilder.setPubDate(pubDate);
+
+            return Optional.of(decoratedBuilder.build());
+        }
+
+    }
+
+
+}

--- a/code/index/java/nu/marginalia/index/model/UnrankedSearchContext.java
+++ b/code/index/java/nu/marginalia/index/model/UnrankedSearchContext.java
@@ -1,0 +1,126 @@
+package nu.marginalia.index.model;
+
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.floats.FloatList;
+import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.longs.*;
+import nu.marginalia.api.searchquery.*;
+import nu.marginalia.api.searchquery.model.compiled.CompiledQuery;
+import nu.marginalia.api.searchquery.model.compiled.CompiledQueryLong;
+import nu.marginalia.api.searchquery.model.compiled.CompiledQueryParser;
+import nu.marginalia.api.searchquery.model.compiled.CqDataInt;
+import nu.marginalia.api.searchquery.model.query.QueryStrategy;
+import nu.marginalia.api.searchquery.model.query.SpecificationLimit;
+import nu.marginalia.api.searchquery.model.results.PrototypeRankingParameters;
+import nu.marginalia.index.CombinedIndexReader;
+import nu.marginalia.index.reverse.IndexLanguageContext;
+import nu.marginalia.index.reverse.query.IndexSearchBudget;
+import nu.marginalia.index.searchset.SearchSet;
+import nu.marginalia.index.searchset.connectivity.ConnectivityView;
+import nu.marginalia.language.keywords.KeywordHasher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import static nu.marginalia.api.searchquery.IndexProtobufCodec.convertSpecLimit;
+
+public class UnrankedSearchContext {
+    private static final Logger logger = LoggerFactory.getLogger(UnrankedSearchContext.class);
+
+    public final IndexSearchBudget budget;
+
+    public final int limitTotal;
+
+    public final LongList termIdsRequire;
+    public final LongList termIdsRequireUnique;
+    public final LongList termIdsExcludes;
+
+    public final IndexLanguageContext languageContext;
+
+    public final Long2ObjectOpenHashMap<String> termIdToString;
+    public final IntList mandatoryDomainIds;
+    public final IntList excludedDomainIds;
+
+    public final long afterCombinedDocId;
+
+
+    public static UnrankedSearchContext create(CombinedIndexReader currentIndex,
+                                               KeywordHasher keywordHasher,
+                                               RpcIndexUnrankedQuery request) {
+
+        var limits = request.getQueryLimits();
+
+        return new UnrankedSearchContext(
+                keywordHasher,
+                request.getLangIsoCode(),
+                currentIndex,
+                request.getTermsRequiredList(),
+                request.getTermsExcludedList(),
+                request.getExcludedDomainIdsList(),
+                request.getRequiredDomainIdsList(),
+                request.getAfterId(),
+                limits);
+    }
+
+    public UnrankedSearchContext(
+            KeywordHasher keywordHasher,
+            String langIsoCode,
+            CombinedIndexReader currentIndex,
+            List<String> termsRequired,
+            List<String> termsExcluded,
+            List<Integer> excludedDomainIdsList,
+            List<Integer> mandatoryDomainIdsList,
+            long afterCombinedDocId,
+            RpcQueryLimits limits)
+    {
+        this.languageContext = currentIndex.createLanguageContext(langIsoCode);
+
+        this.budget = new IndexSearchBudget(Math.max(limits.getTimeoutMs()/2, limits.getTimeoutMs()-10));
+
+        this.excludedDomainIds = new IntArrayList(excludedDomainIdsList);
+        this.mandatoryDomainIds = new IntArrayList(mandatoryDomainIdsList);
+
+        this.afterCombinedDocId = afterCombinedDocId;
+        this.limitTotal = limits.getResultsTotal();
+
+        this.termIdsExcludes = new LongArrayList();
+        this.termIdsRequire = new LongArrayList();
+
+        for (var word : termsRequired) {
+            termIdsRequire.add(keywordHasher.hashKeyword(word));
+        }
+
+        for (var word : termsExcluded) {
+            termIdsExcludes.add(keywordHasher.hashKeyword(word));
+        }
+
+        LongArrayList termIdsList = new LongArrayList();
+        termIdToString = new Long2ObjectOpenHashMap<>();
+
+        for (String term : termsRequired) {
+            long id = keywordHasher.hashKeyword(term);
+            termIdsList.add(id);
+            termIdToString.put(id, term);
+        }
+
+        for (var term : termsExcluded) {
+            long id = keywordHasher.hashKeyword(term);
+            if (termIdToString.containsKey(id))
+                continue;
+            termIdToString.put(id, term);
+        }
+
+        termIdsRequireUnique = new LongArrayList(new LongOpenHashSet(termIdsList));
+        termIdsRequireUnique.sort(Long::compareTo);
+    }
+
+    public long[] sortedDistinctIncludes(LongComparator comparator) {
+        LongList list = new LongArrayList(termIdsRequireUnique);
+        list.sort(comparator);
+        return list.toLongArray();
+    }
+
+}

--- a/code/services-application/api-service/java/nu/marginalia/api/ApiSearchOperator.java
+++ b/code/services-application/api-service/java/nu/marginalia/api/ApiSearchOperator.java
@@ -2,10 +2,7 @@ package nu.marginalia.api;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import nu.marginalia.api.model.ApiLicense;
-import nu.marginalia.api.model.ApiSearchResult;
-import nu.marginalia.api.model.ApiSearchResultQueryDetails;
-import nu.marginalia.api.model.ApiSearchResults;
+import nu.marginalia.api.model.*;
 import nu.marginalia.api.searchquery.QueryClient;
 import nu.marginalia.api.searchquery.QueryFilterSpec;
 import nu.marginalia.api.searchquery.RpcQueryLimits;
@@ -13,6 +10,7 @@ import nu.marginalia.api.searchquery.model.SearchFilterDefaults;
 import nu.marginalia.api.searchquery.model.query.NsfwFilterTier;
 import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
 import nu.marginalia.model.idx.WordFlags;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -28,6 +26,27 @@ public class ApiSearchOperator {
     @Inject
     public ApiSearchOperator(QueryClient queryClient) {
         this.queryClient = queryClient;
+    }
+
+    public ApiUnrankedSearchResults unrankedQuery(String query, int count, int timeout, String cursor, String langIsoCode, ApiLicense license) throws TimeoutException {
+        var rsp = queryClient.unrankedSearch(
+                List.of(StringUtils.split(query, " ")),
+                langIsoCode,
+                RpcQueryLimits.newBuilder()
+                        .setResultsTotal(Math.min(100, count))
+                        .setTimeoutMs(Math.clamp(timeout, 50, 250))
+                        .build(),
+                cursor);
+
+        return new ApiUnrankedSearchResults(license.license(), query,
+                rsp.encodedCursor(),
+                rsp.results()
+                        .stream()
+                        .map(this::convert)
+                        .sorted(Comparator.comparing(ApiSearchResult::getQuality))
+                        .limit(count)
+                        .collect(Collectors.toList()));
+
     }
 
     public ApiSearchResults v2query(String query,

--- a/code/services-application/api-service/java/nu/marginalia/api/ApiV2.java
+++ b/code/services-application/api-service/java/nu/marginalia/api/ApiV2.java
@@ -91,6 +91,7 @@ public class ApiV2 implements Extension {
 
         jooby.get("/api/v2/key", this::keyInfo);
         jooby.get("/api/v2/search", this::search);
+        jooby.get("/api/v2/unranked", this::searchUnranked);
 
         jooby.get("/api/v2/filter", this::listFilters);
 
@@ -404,6 +405,115 @@ public class ApiV2 implements Extension {
         return gson.toJson(results);
     }
 
+
+    @NotNull
+    private Object searchUnranked(Context ctx) {
+        Value apiKeyVal = ctx.header("API-Key");
+        if (apiKeyVal.isMissing()) {
+            ctx.setResponseCode(400);
+            return "Missing API-Key header";
+        }
+
+        ApiLicense license;
+        try {
+            license = licenseService.getLicense(apiKeyVal.value());
+        } catch (LicenseService.NoSuchKeyException | IOException ex) {
+            ctx.setResponseCode(StatusCode.UNAUTHORIZED);
+            return "";
+        }
+
+        Value queryVal = ctx.query("query");
+        if (!queryVal.isPresent()) {
+            ctx.setResponseCode(400);
+            return "";
+        }
+        String query = queryVal.value();
+
+        // Voluntary over-billing protection via request header
+        int limitBillableRequestsHeader = ctx.header("API-Limit-Billable-Requests").intValue(-1);
+        if (limitBillableRequestsHeader >= 0
+                && license.hasOption(ApiLicenseOptions.ALLOW_QUERY_DAILY_OVERUSE)
+                && !rateLimiterService.hasRemainingDailyLimit(license))
+        {
+
+            long billableApiUsage = rateLimiterService.estimatedTotalApiUseForPeriod(license);
+
+            if (billableApiUsage + 1 >= limitBillableRequestsHeader) {
+                DailyLimitState limitState = new DailyLimitState.OverLimitBlock();
+
+                ctx.setResponseHeader("API-Remaining-Daily-Capacity", limitState.remaining());
+                ctx.setResponseHeader("API-Event-Type", limitState.name());
+                ctx.setResponseHeader("API-Billable-Requests", billableApiUsage);
+
+                ctx.setResponseCode(429);
+
+                return "API usage exceeds provided API-Limit-Billable-Requests header";
+            }
+        }
+
+        ApiUnrankedSearchResults results = null;
+        DailyLimitState limitState;
+
+
+        if (!rateLimiterService.isAllowedQPM(license)) {
+            ApiMetrics.wmsa_api_timeout_count.labelValues(license.key()).inc();
+            ctx.setResponseCode(429);
+
+            return "QPM Limit Exceeded";
+        }
+
+        if (!rateLimiterService.isAllowedQPD(license)) {
+            ApiMetrics.wmsa_api_timeout_count.labelValues(license.key()).inc();
+            ctx.setResponseCode(429);
+
+            limitState = new DailyLimitState.OverLimitBlock();
+
+            ctx.setResponseHeader("API-Remaining-Daily-Capacity", limitState.remaining());
+            ctx.setResponseHeader("API-Event-Type", limitState.name());
+
+            return "Daily Limit Exceeded";
+        }
+
+        // When no cached response, do the search and cache the result
+
+        try {
+            results = doUnrankedSearch(license, query, ctx);
+            if (results == null) {
+                return "Query Execution Failed";
+            }
+        }
+        catch (RuntimeException ex) {
+            logger.error("Error execuing query {}", ex);
+
+            ctx.setResponseCode(500);
+            return "Query Execution Failed";
+        }
+
+        if (results.getResults().size() > 0) {
+            limitState = rateLimiterService.registerSuccessfulQuery(license);
+        } else {
+            int remaining = rateLimiterService.remainingDailyLimit(license);
+            limitState = new DailyLimitState.NoResults(remaining);
+        }
+
+
+        if (license.hasOption(ApiLicenseOptions.ADUIT_USAGE)) {
+            logger.info(apiUsageMarker, "{} {} {}", license.key(), limitState, ctx.header(realIpHeader));
+        }
+
+        if (license.hasOption(ApiLicenseOptions.ALLOW_QUERY_DAILY_OVERUSE)) {
+            long billableApiUsage = rateLimiterService.estimatedTotalApiUseForPeriod(license);
+            ctx.setResponseHeader("API-Billable-Requests", billableApiUsage);
+        }
+
+        ctx.setResponseType("application/json");
+        ctx.setResponseHeader("API-Remaining-Daily-Capacity", limitState.remaining());
+        ctx.setResponseHeader("API-Event-Type", limitState.name());
+
+        return gson.toJson(results);
+    }
+
+
     @NotNull
     private Object siteInfo(Context ctx) {
         Value apiKeyVal = ctx.header("API-Key");
@@ -659,6 +769,27 @@ public class ApiV2 implements Extension {
         {
             return searchOperator
                     .v2query(query, count, timeout, domainCount, page, filter, nsfwFilterTier, langIsoCode, license);
+        }
+        catch (TimeoutException ex) {
+            context.setResponseCode(504);
+            return null;
+        }
+    }
+
+
+
+    private ApiUnrankedSearchResults doUnrankedSearch(ApiLicense license, String query, Context context) {
+        int count = context.query().get("count").intValue(100);
+        int timeout = context.query().get("timeout").intValue(150);
+        String cursor = context.query().get("cursor").value("");
+        String langIsoCode = context.query("lang").value("en");
+
+        final QueryFilterSpec filter;
+
+        try (var _ = ApiMetrics.wmsa_api_query_time.labelValues(license.key()).startTimer())
+        {
+            return searchOperator
+                    .unrankedQuery(query, count, timeout, cursor, langIsoCode, license);
         }
         catch (TimeoutException ex) {
             context.setResponseCode(504);

--- a/code/services-application/api-service/java/nu/marginalia/api/model/ApiUnrankedSearchResults.java
+++ b/code/services-application/api-service/java/nu/marginalia/api/model/ApiUnrankedSearchResults.java
@@ -1,0 +1,47 @@
+package nu.marginalia.api.model;
+
+import java.util.List;
+
+public class ApiUnrankedSearchResults {
+    private final String license;
+
+    private String cursorNext;
+
+    private final String query;
+    private final List<ApiSearchResult> results;
+
+    public ApiUnrankedSearchResults(String license,
+                                    String query,
+                                    String cursorNext,
+                                    List<ApiSearchResult> results) {
+        this.license = license;
+        this.query = query;
+        this.results = results;
+    }
+
+    public String getLicense() {
+        return this.license;
+    }
+
+    public String getQuery() {
+        return this.query;
+    }
+
+    public String getCursorNext() { return this.cursorNext; }
+
+    public List<ApiSearchResult> getResults() {
+        return this.results;
+    }
+
+    public ApiUnrankedSearchResults withLicense(String license) {
+        return this.license == license ? this : new ApiUnrankedSearchResults(license, this.query, this.cursorNext, this.results);
+    }
+
+    public ApiUnrankedSearchResults withQuery(String query) {
+        return this.query == query ? this : new ApiUnrankedSearchResults(this.license, query, this.cursorNext, this.results);
+    }
+
+    public ApiUnrankedSearchResults withResults(List<ApiSearchResult> results) {
+        return this.results == results ? this : new ApiUnrankedSearchResults(this.license, this.query, this.cursorNext, results);
+    }
+}

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
@@ -10,6 +10,7 @@ import nu.marginalia.api.searchquery.RpcQueryLimits;
 import nu.marginalia.api.searchquery.RpcTemporalBias;
 import nu.marginalia.api.searchquery.model.query.NsfwFilterTier;
 import nu.marginalia.api.searchquery.model.query.QueryResponse;
+import nu.marginalia.api.searchquery.model.query.UnrankedQueryResponse;
 import nu.marginalia.api.searchquery.model.results.DecoratedSearchResultItem;
 import nu.marginalia.bbpc.BrailleBlockPunchCards;
 import nu.marginalia.db.DbDomainQueries;
@@ -80,38 +81,42 @@ public class SearchOperator {
         this.searchVisitorCount = searchVisitorCount;
     }
 
-    public SimpleSearchResults doSiteSearch(String domain,
-                                        int domainId,
-                                        int count,
-                                        int page) throws TimeoutException {
-        var queryResponse = queryClient.search(
-                QueryFilterSpec.FilterAdHoc.builder().domainsInclude(IntList.of(domainId)).build(),
-                "site:"+domain,
+    public UnrankedSearchResults doSiteSearch(String domain, int count, String cursor) throws TimeoutException {
+
+        var rs =  queryClient.unrankedSearch(
+                List.of("site:"+domain),
                 "en",
-                NsfwFilterTier.DANGER,
                 RpcQueryLimits.newBuilder()
                         .setResultsTotal(count)
-                        .setResultsByDomain(count)
                         .setTimeoutMs(100)
                         .build(),
-                page
+                cursor
         );
 
-        return getResultsFromQuery(queryResponse);
+        List<UrlDetails> details = rs.results().stream()
+                .map(SearchOperator::createDetails)
+                .toList();
+
+        return new UnrankedSearchResults(details, rs.encodedCursor());
     }
 
-    public SimpleSearchResults doBacklinkSearch(String domain, int page) throws TimeoutException {
+    public UnrankedSearchResults doBacklinkSearch(String domain, String cursor) throws TimeoutException {
 
-        var queryResponse = queryClient.search(
-                new QueryFilterSpec.NoFilter(),
-                "links:"+domain,
+        var rs =  queryClient.unrankedSearch(
+                List.of("links:"+domain),
                 "en",
-                NsfwFilterTier.DANGER,
-                shallowLimit,
-                page
+                RpcQueryLimits.newBuilder()
+                        .setResultsTotal(10)
+                        .setTimeoutMs(100)
+                        .build(),
+                cursor
         );
 
-        return getResultsFromQuery(queryResponse);
+        List<UrlDetails> details = rs.results().stream()
+                .map(SearchOperator::createDetails)
+                .toList();
+
+        return new UnrankedSearchResults(details, rs.encodedCursor());
     }
 
     public SimpleSearchResults doLinkSearch(String source, String dest) throws TimeoutException {

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UnrankedSearchResults.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UnrankedSearchResults.java
@@ -1,0 +1,13 @@
+package nu.marginalia.search.model;
+
+import java.util.List;
+
+public class UnrankedSearchResults {
+    public final List<UrlDetails> results;
+    public final String cursor;
+
+    public UnrankedSearchResults(List<UrlDetails> results, String cursor) {
+        this.results = results;
+        this.cursor = cursor;
+    }
+}

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchSiteInfoService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchSiteInfoService.java
@@ -184,7 +184,8 @@ public class SearchSiteInfoService {
             Context context,
             @PathParam String domainName,
             @QueryParam String view,
-            @QueryParam Integer page
+            @QueryParam Integer page,
+            @QueryParam String cursor
     ) throws SQLException, ExecutionException, TimeoutException {
 
         if (null == domainName || domainName.isBlank()) {
@@ -213,8 +214,8 @@ public class SearchSiteInfoService {
         String sst = interceptResult.sst();
 
         SiteInfoModel model = switch (view) {
-            case "links" -> listLinks(domainName, sst, page);
-            case "docs" -> listDocs(domainName, sst, page);
+            case "links" -> listLinks(domainName, sst, cursor);
+            case "docs" -> listDocs(domainName, sst, cursor);
             case "info" -> listInfo(context, domainName, sst);
             case "traffic" -> listSiteRequests(context, domainName, sst);
             case "availability" -> listAvailabilityEvents(context, domainName, sst);
@@ -310,13 +311,14 @@ public class SearchSiteInfoService {
     }
 
 
-    private Backlinks listLinks(String domainName, String sst, int page) throws TimeoutException {
-        var results = searchOperator.doBacklinkSearch(domainName, page);
+    private Backlinks listLinks(String domainName, String sst, String cursor) throws TimeoutException {
+        var results = searchOperator.doBacklinkSearch(domainName, cursor);
+
         return new Backlinks(domainName,
                 sst,
                 domainQueries.tryGetDomainId(new EdgeDomain(domainName)).orElse(-1),
                 GroupedUrlDetails.groupResults(results.results),
-                results.resultPages
+                results.cursor
         );
     }
 
@@ -368,7 +370,7 @@ public class SearchSiteInfoService {
             sampleResults = List.of();
         }
         else {
-            sampleResults = searchOperator.doSiteSearch(domainName, domainId, 5, 1).results;
+            sampleResults = searchOperator.doSiteSearch(domainName, 5, "").results;
         }
 
         if (!sampleResults.isEmpty()) {
@@ -466,15 +468,15 @@ public class SearchSiteInfoService {
                 .build();
     }
 
-    private Docs listDocs(String domainName, String sst, int page) throws TimeoutException {
+    private Docs listDocs(String domainName, String sst, String cursor) throws TimeoutException {
         int domainId = domainQueries.tryGetDomainId(new EdgeDomain(domainName)).orElse(-1);
-        var results = searchOperator.doSiteSearch(domainName, domainId, 100, page);
+        var results = searchOperator.doSiteSearch(domainName, 100, cursor);
 
         return new Docs(domainName,
                 sst,
                 domainQueries.tryGetDomainId(new EdgeDomain(domainName)).orElse(-1),
                 results.results.stream().sorted(Comparator.comparing(deets -> -deets.topology)).toList(),
-                results.resultPages
+                results.cursor
                 );
     }
 
@@ -784,7 +786,7 @@ public class SearchSiteInfoService {
                        String sst,
                        long domainId,
                        List<UrlDetails> results,
-                       List<ResultsPage> pages) implements SiteInfoModel  {
+                       String cursorNext) implements SiteInfoModel  {
 
         public String focusDomain() { return domain; }
 
@@ -799,7 +801,7 @@ public class SearchSiteInfoService {
                             String sst,
                             long domainId,
                             List<GroupedUrlDetails> results,
-                            List<ResultsPage> pages
+                            String cursorNext
                             ) implements SiteInfoModel
     {
         public String query() { return "links:" + domain; }

--- a/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
@@ -43,15 +43,9 @@
 @endfor
 
 <!-- Pagination -->
-@if (backlinks.pages().size() > 1)
+@if (!"FIN".equals(backlinks.cursorNext()))
     <div class="mt-8 flex justify-center space-x-2 font-mono text-sm">
-        @for(ResultsPage page : backlinks.pages())
-            @if (page.current())
-                <a href="?view=links&page=${page.number()}" class="px-2 py-1 border dark:border-gray-600 border-gray-300 bg-gray-100 dark:bg-gray-900">${page.number()}</a>
-            @else
-                <a href="?view=links&page=${page.number()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">${page.number()}</a>
-            @endif
-        @endfor
+        <a href="?view=links&cursor=${backlinks.cursorNext()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
     </div>
 @endif
 </div>

--- a/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
@@ -43,9 +43,9 @@
 @endfor
 
 <!-- Pagination -->
-@if (!"FIN".equals(backlinks.cursorNext()))
+@if (!"FIN".equals(backlinks.cursorNext()) && !backlinks.results().isEmpty())
     <div class="mt-8 flex justify-center space-x-2 font-mono text-sm">
-        <a href="?view=links&cursor=${backlinks.cursorNext()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
+        <a href="?view=links&cursor=${backlinks.cursorNext()}&sst=${backlinks.sst()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
     </div>
 @endif
 </div>

--- a/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
@@ -73,9 +73,9 @@
 @endfor
 
 <!-- Pagination -->
-@if (!"FIN".equals(docs.cursorNext()))
+@if (!"FIN".equals(docs.cursorNext()) && !docs.results().isEmpty())
     <div class="mt-8 flex justify-center space-x-2 font-mono text-sm">
-        <a href="?view=docs&cursor=${docs.cursorNext()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
+        <a href="?view=docs&cursor=${docs.cursorNext()}&sst=${docs.sst()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
     </div>
 @endif
 

--- a/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
@@ -73,15 +73,9 @@
 @endfor
 
 <!-- Pagination -->
-@if (docs.pages().size() > 1)
+@if (!"FIN".equals(docs.cursorNext()))
     <div class="mt-8 flex justify-center space-x-2 font-mono text-sm">
-        @for(ResultsPage page : docs.pages())
-            @if (page.current())
-                <a href="?view=docs&page=${page.number()}" class="px-2 py-1 border dark:border-gray-600 border-gray-300 bg-gray-100 dark:bg-gray-900">${page.number()}</a>
-            @else
-                <a href="?view=docs&page=${page.number()}" class="px-2 py-1 bg-white dark:bg-gray-800 dark:text-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">${page.number()}</a>
-            @endif
-        @endfor
+        <a href="?view=docs&cursor=${docs.cursorNext()}" class="px-2 py-1 bg-white border dark:border-gray-600 border-gray-300 hover:bg-gray-100 dark:bg-gray-800 hover:bg-gray-900">More</a>
     </div>
 @endif
 

--- a/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
@@ -53,6 +53,7 @@ public class MockedSearchResults {
                 DomainIndexingState.ACTIVE,
                 0.5,
                 8,
+                0,
                 "",
                 mockPositionsMask(),
                 2,

--- a/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
@@ -245,10 +245,7 @@ public class MockedSearchResults {
                                 )
                         )
                 ),
-                List.of(
-                        new ResultsPage(1, true, "#"),
-                        new ResultsPage(2, false, "#")
-                        )
+                "CUR"
         );
     }
 
@@ -262,10 +259,7 @@ public class MockedSearchResults {
                         mockUrlDetails("https://www.example.com/", "dolor sit"),
                         mockUrlDetails("https://www.example.com/", "amet quia")
                 ),
-                List.of(
-                        new ResultsPage(1, true, "#"),
-                        new ResultsPage(2, false, "#")
-                )
+                "CUR"
         );
     }
 


### PR DESCRIPTION
For some use cases, such as listing backlinks or enumerating documents, running the full ranked query code path is extremely wasteful, and leads to an artificial limit in how many results can be returned that is quite low.

This change adds a new unranked query execution path, that is both signficantly cheaper to execute, and can return an unbounded number of results using an opaque pagination cursor.  