### PR TITLE
Fix comma splice in legal text

### DIFF
--- a/code/services-application/search-service/resources/jte/part/footerLegal.jte
+++ b/code/services-application/search-service/resources/jte/part/footerLegal.jte
@@ -9,7 +9,7 @@
             to provide service functionality.
             </span>
             <span>
-            Access logs containing IP-addresses are retained for up to 24 hours,
+            Access logs containing IP-addresses are retained for up to 24 hours;
             anonymized logs with source addresses removed are sometimes kept longer
             to help diagnose bugs.
             </span>


### PR DESCRIPTION
Two clauses which can stand alone as sentences should be joined with a semicolon, not a comma. It's pedantic, I know, but it makes my brain itch seeing it wrong.