### PR TITLE
Experimental emergency anti scrape measures

### DIFF
--- a/code/common/linkdb/java/nu/marginalia/linkdb/docs/DocumentDbReader.java
+++ b/code/common/linkdb/java/nu/marginalia/linkdb/docs/DocumentDbReader.java
@@ -148,4 +148,23 @@ public class DocumentDbReader {
 
         return ret;
     }
+
+    public String getUrl(long docId) throws SQLException {
+
+        if (connection == null || connection.isClosed()) {
+            throw new IllegalStateException("URL query temporarily unavailable due to database switch");
+        }
+
+        try (var stmt = connection.createStatement()) {
+            var rs = stmt.executeQuery("""
+                SELECT URL FROM DOCUMENT WHERE ID = 
+                """ + docId /* safe, long type */);
+            if (rs.next()) {
+                return rs.getString("URL");
+            }
+            else {
+                return null;
+            }
+        }
+    }
 }

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/IndexUrlClient.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/IndexUrlClient.java
@@ -1,0 +1,48 @@
+package nu.marginalia.api.searchquery;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.grpc.StatusRuntimeException;
+import nu.marginalia.service.client.GrpcChannelPoolFactoryIf;
+import nu.marginalia.service.client.GrpcMultiNodeChannelPool;
+import nu.marginalia.service.discovery.property.ServiceKey;
+import nu.marginalia.service.discovery.property.ServicePartition;
+import nu.marginalia.service.server.Initialization;
+import org.apache.logging.log4j.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+@Singleton
+public class IndexUrlClient {
+
+    private static final Logger log = LoggerFactory.getLogger(IndexUrlClient.class);
+
+    private final GrpcMultiNodeChannelPool<IndexUrlApiGrpc.IndexUrlApiBlockingStub> indexApiPool;
+
+    @Inject
+    public IndexUrlClient(GrpcChannelPoolFactoryIf channelPoolFactory, Initialization initialization) throws InterruptedException
+    {
+        this.indexApiPool = channelPoolFactory.createMulti(
+                ServiceKey.forGrpcApi(IndexUrlApiGrpc.class, ServicePartition.multi()),
+                IndexUrlApiGrpc::newBlockingStub);
+    }
+
+    public Optional<String> getUrl(int node, long docId) throws TimeoutException {
+        try {
+            return Optional.ofNullable(indexApiPool.call(IndexUrlApiGrpc.IndexUrlApiBlockingStub::getUrl)
+                    .forNode(node)
+                    .run(RpcDocumentIdRequest.newBuilder().setDocId(docId).build())
+                    .getUrl())
+                    .filter(Strings::isNotBlank);
+        }
+        catch (StatusRuntimeException ex) {
+            log.warn("Failed to get URL for document {}:{}", node, docId, ex);
+
+            return Optional.empty();
+        }
+    }
+
+}

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryProtobufCodec.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/QueryProtobufCodec.java
@@ -190,6 +190,7 @@ public class QueryProtobufCodec {
 
         return new SearchResultItem(
                 rawItem.getCombinedId(),
+                rawItem.getNode(),
                 rawItem.getEncodedDocMetadata(),
                 rawItem.getHtmlFeatures(),
                 keywordScores,

--- a/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/results/SearchResultItem.java
+++ b/code/functions/search-query/api/java/nu/marginalia/api/searchquery/model/results/SearchResultItem.java
@@ -17,6 +17,9 @@ public class SearchResultItem implements Comparable<SearchResultItem> {
      */
     public final long combinedId;
 
+    /** The index node id the document came from */
+    public final int nodeId;
+
     /**
      * Encoded document metadata
      */
@@ -40,11 +43,13 @@ public class SearchResultItem implements Comparable<SearchResultItem> {
     public DebugRankingFactors debugRankingFactors;
 
     public SearchResultItem(long combinedId,
+                            int nodeId,
                             long encodedDocMetadata,
                             int htmlFeatures,
                             double score,
                             long bestPositions) {
         this.combinedId = combinedId;
+        this.nodeId = nodeId;
         this.encodedDocMetadata = encodedDocMetadata;
         this.bestPositions = bestPositions;
         this.keywordScores = new ArrayList<>();
@@ -52,8 +57,17 @@ public class SearchResultItem implements Comparable<SearchResultItem> {
         this.scoreValue = score;
     }
 
-    public SearchResultItem(long combinedId, long encodedDocMetadata, int htmlFeatures, List<SearchResultKeywordScore> keywordScores, boolean hasPrioTerm, long bestPositions, DebugRankingFactors debugRankingFactors, double scoreValue) {
+    public SearchResultItem(long combinedId,
+                            int nodeId,
+                            long encodedDocMetadata,
+                            int htmlFeatures,
+                            List<SearchResultKeywordScore> keywordScores,
+                            boolean hasPrioTerm,
+                            long bestPositions,
+                            DebugRankingFactors debugRankingFactors,
+                            double scoreValue) {
         this.combinedId = combinedId;
+        this.nodeId = nodeId;
         this.encodedDocMetadata = encodedDocMetadata;
         this.htmlFeatures = htmlFeatures;
         this.keywordScores = keywordScores;

--- a/code/functions/search-query/api/src/main/protobuf/query-api.proto
+++ b/code/functions/search-query/api/src/main/protobuf/query-api.proto
@@ -15,6 +15,17 @@ service IndexApi {
   rpc unrankedQuery(RpcIndexUnrankedQuery) returns (RpcIndexQueryResponse) {}
 }
 
+service IndexUrlApi {
+  rpc getUrl(RpcDocumentIdRequest) returns (RpcIndexUrlResponse) {}
+}
+
+message RpcDocumentIdRequest {
+  int64 docId = 1;
+}
+message RpcIndexUrlResponse {
+  string url = 1;
+}
+
 message Empty {}
 
 message RpcIndexQueryResponse {

--- a/code/functions/search-query/api/src/main/protobuf/query-api.proto
+++ b/code/functions/search-query/api/src/main/protobuf/query-api.proto
@@ -212,6 +212,8 @@ message RpcRawResultItem {
   bool hasPriorityTerms = 6; // true if this word is important to the document
   MATCH_TYPE matchType = 7; // the type of match this result represents
 
+  int32 node = 8;
+
   enum MATCH_TYPE {
     FLAGS = 0;
     PROXIMITY = 1;

--- a/code/index/index-perftest/java/nu/marginalia/index/perftest/PerfTestMain.java
+++ b/code/index/index-perftest/java/nu/marginalia/index/perftest/PerfTestMain.java
@@ -241,7 +241,7 @@ public class PerfTestMain {
             var execution = new IndexQueryExecution(indexReader,
                     new DocumentDbReader(indexDir.resolve("ldbr/documents.db")),
                     rankingService,
-                    SearchContext.create(indexReader, new KeywordHasher.AsciiIsh(), parsedQuery, new SearchSetAny(), ConnectivityView.empty()), 1);
+                    SearchContext.create(indexReader, 1, new KeywordHasher.AsciiIsh(), parsedQuery, new SearchSetAny(), ConnectivityView.empty()), 1);
             long start = System.nanoTime();
             execution.run();
             long end = System.nanoTime();
@@ -291,7 +291,7 @@ public class PerfTestMain {
 
         System.out.println("Query compiled to: " + parsedQuery.getTerms().getCompiledQuery());
 
-        SearchContext searchContext = SearchContext.create(indexReader, new KeywordHasher.AsciiIsh(), parsedQuery, new SearchSetAny(), ConnectivityView.empty());
+        SearchContext searchContext = SearchContext.create(indexReader, 1, new KeywordHasher.AsciiIsh(), parsedQuery, new SearchSetAny(), ConnectivityView.empty());
 
 
         Instant runEndTime = Instant.now().plus(runTime);

--- a/code/index/java/nu/marginalia/index/IndexGrpcService.java
+++ b/code/index/java/nu/marginalia/index/IndexGrpcService.java
@@ -121,7 +121,7 @@ public class IndexGrpcService
 
                             CombinedIndexReader index = indexReference.get();
 
-                            SearchContext rankingContext = SearchContext.create(index, hasher, request, set, connectivityView);
+                            SearchContext rankingContext = SearchContext.create(index,nodeId, hasher, request, set, connectivityView);
                             IndexQueryExecution queryExecution = new IndexQueryExecution(index, documentDbReader, rankingService, rankingContext, nodeId);
                             return queryExecution.run();
 
@@ -248,7 +248,7 @@ public class IndexGrpcService
 
             CombinedIndexReader currentIndex = indexReference.get();
 
-            SearchContext context = SearchContext.create(currentIndex,
+            SearchContext context = SearchContext.create(currentIndex, nodeId,
                     keywordHasherByLangIso.get("en"), request, getSearchSet(request),
                     ConnectivityView.empty()
                     );

--- a/code/index/java/nu/marginalia/index/IndexQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexQueryExecution.java
@@ -672,6 +672,7 @@ public class IndexQueryExecution {
             rawItem.setHtmlFeatures(resultItem.htmlFeatures);
             rawItem.setEncodedDocMetadata(resultItem.encodedDocMetadata);
             rawItem.setHasPriorityTerms(resultItem.hasPrioTerm);
+            rawItem.setNode(resultItem.nodeId);
 
             for (var score : resultItem.keywordScores) {
                 rawItem.addKeywordScores(

--- a/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
+++ b/code/index/java/nu/marginalia/index/IndexUnrankedQueryExecution.java
@@ -29,6 +29,7 @@ public class IndexUnrankedQueryExecution {
 
     private static final Logger logger = LoggerFactory.getLogger(IndexUnrankedQueryExecution.class);
 
+    private final int nodeId;
     private final DocumentDbReader documentDbReader;
     private final UnrankedSearchContext searchContext;
     private final String nodeName;
@@ -62,6 +63,7 @@ public class IndexUnrankedQueryExecution {
         this.documentDbReader = documentDbReader;
         this.searchContext = searchContext;
         this.nodeName = Integer.toString(serviceNode);
+        this.nodeId = serviceNode;
         this.rankingService = rankingService;
 
         this.lastId = searchContext.afterCombinedDocId;
@@ -96,6 +98,7 @@ public class IndexUnrankedQueryExecution {
                             var result = new RankableDocument(nextId);
 
                             result.item = new SearchResultItem(nextId,
+                                    nodeId,
                                     currentIndex.getDocumentMetadata(nextId),
                                     currentIndex.getHtmlFeatures(nextId),
                                     0, 0L);
@@ -137,7 +140,7 @@ public class IndexUnrankedQueryExecution {
 
                 int pubDate = currentIndex.getDocPubDate(doc.item.combinedId);
 
-                converter.convert(doc, docData, leads[i], pubDate).ifPresent(ret::add);
+                converter.convert(doc, docData, leads[i], nodeId, pubDate).ifPresent(ret::add);
             }
         }
 
@@ -152,6 +155,7 @@ public class IndexUnrankedQueryExecution {
         public Optional<RpcDecoratedResultItem> convert(RankableDocument doc,
                                                  DocdbUrlDetail docData,
                                                  @Nullable String leadDescription,
+                                                 int nodeId,
                                                  int pubDate) {
             SearchResultItem resultItem = doc.item;
 
@@ -166,6 +170,7 @@ public class IndexUnrankedQueryExecution {
             rawItem.setHtmlFeatures(resultItem.htmlFeatures);
             rawItem.setEncodedDocMetadata(resultItem.encodedDocMetadata);
             rawItem.setHasPriorityTerms(resultItem.hasPrioTerm);
+            rawItem.setNode(resultItem.nodeId);
 
             for (var score : resultItem.keywordScores) {
                 rawItem.addKeywordScores(

--- a/code/index/java/nu/marginalia/index/IndexUrlApiGrpcService.java
+++ b/code/index/java/nu/marginalia/index/IndexUrlApiGrpcService.java
@@ -1,0 +1,52 @@
+package nu.marginalia.index;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import nu.marginalia.api.searchquery.IndexUrlApiGrpc;
+import nu.marginalia.api.searchquery.RpcDocumentIdRequest;
+import nu.marginalia.api.searchquery.RpcIndexUrlResponse;
+import nu.marginalia.linkdb.docs.DocumentDbReader;
+import nu.marginalia.service.server.DiscoverableService;
+
+import java.sql.SQLException;
+
+@Singleton
+public class IndexUrlApiGrpcService extends IndexUrlApiGrpc.IndexUrlApiImplBase
+        implements DiscoverableService
+{
+
+    private final DocumentDbReader documentDbReader;
+
+    @Inject
+    public IndexUrlApiGrpcService(DocumentDbReader documentDbReader) {
+        this.documentDbReader = documentDbReader;
+    }
+
+    @Override
+    public void getUrl(RpcDocumentIdRequest request,
+                       StreamObserver<RpcIndexUrlResponse> responseObserver)
+    {
+        try {
+            String url = documentDbReader.getUrl(request.getDocId());
+
+            if (url != null) {
+                responseObserver.onNext(RpcIndexUrlResponse.newBuilder().setUrl(url).build());
+                responseObserver.onCompleted();
+            }
+            else {
+                // Don't return a 404, just don't return a blank URL so we don't drag a stack trace across for every bad URL
+                responseObserver.onNext(RpcIndexUrlResponse.newBuilder().build());
+                responseObserver.onCompleted();
+                return;
+            }
+        }
+        catch (IllegalStateException ex) {
+            responseObserver.onError(Status.UNAVAILABLE.withCause(ex).asRuntimeException());
+        }
+        catch (SQLException | RuntimeException ex) {
+            responseObserver.onError(Status.INTERNAL.withCause(ex).asRuntimeException());
+        }
+    }
+}

--- a/code/index/java/nu/marginalia/index/model/SearchContext.java
+++ b/code/index/java/nu/marginalia/index/model/SearchContext.java
@@ -84,12 +84,14 @@ public class SearchContext {
 
     public final ConnectivityView connectivityView;
 
+    public final int nodeId;
+
     public static SearchContext create(CombinedIndexReader currentIndex,
+                                       int nodeId,
                                        KeywordHasher keywordHasher,
                                        RpcIndexQuery request,
                                        SearchSet searchSet,
-                                       ConnectivityView connectivityView
-                                       ) {
+                                       ConnectivityView connectivityView) {
 
         var limits = request.getQueryLimits();
         var queryTerms = request.getTerms();
@@ -105,6 +107,7 @@ public class SearchContext {
         var rankingParams = request.hasParameters() ? request.getParameters() : PrototypeRankingParameters.sensibleDefaults();
 
         return new SearchContext(
+                nodeId,
                 keywordHasher,
                 connectivityView,
                 request.getLangIsoCode(),
@@ -120,6 +123,7 @@ public class SearchContext {
     }
 
     public SearchContext(
+            int nodeId,
             KeywordHasher keywordHasher,
             ConnectivityView connectivityView,
             String langIsoCode,
@@ -133,6 +137,7 @@ public class SearchContext {
             List<Float> priorityDomainIdsAmountsList,
             RpcQueryLimits limits)
     {
+        this.nodeId = nodeId;
         this.connectivityView = connectivityView;
         this.docCount = currentIndex.totalDocCount();
         this.languageContext = currentIndex.createLanguageContext(langIsoCode);

--- a/code/index/java/nu/marginalia/index/results/IndexResultRankingService.java
+++ b/code/index/java/nu/marginalia/index/results/IndexResultRankingService.java
@@ -202,6 +202,7 @@ public class IndexResultRankingService {
         }
 
         SearchResultItem ret = new SearchResultItem(combinedId,
+                rankingContext.nodeId,
                 docMetadata,
                 htmlFeatures,
                 score,

--- a/code/index/test/nu/marginalia/index/ResultPriorityQueueTest.java
+++ b/code/index/test/nu/marginalia/index/ResultPriorityQueueTest.java
@@ -123,7 +123,7 @@ public class ResultPriorityQueueTest {
     public static RankableDocument doc(int domainId, int ordinal, double score) {
         long combinedId = UrlIdCodec.encodeId(domainId, ordinal);
         RankableDocument d = new RankableDocument(combinedId);
-        d.item = new SearchResultItem(combinedId, 0L, 0, score, 0L);
+        d.item = new SearchResultItem(combinedId, 1, 0L, 0, score, 0L);
         return d;
     }
 

--- a/code/libraries/scrape-stopper/java/nu/marginalia/scrapestopper/ScrapeStopper.java
+++ b/code/libraries/scrape-stopper/java/nu/marginalia/scrapestopper/ScrapeStopper.java
@@ -137,6 +137,10 @@ public class ScrapeStopper {
         return validationRatePerZone.computeIfAbsent(zone, z -> new ValidationRate(2.0));
     }
 
+    public boolean isStrained() {
+        return validationRatePerZone.values().stream().anyMatch(ValidationRate::isStrained);
+    }
+
 }
 
 
@@ -228,6 +232,7 @@ class Token {
     public boolean isExpired() {
         return Instant.now().isAfter(validUntil) || remainingUses.getAcquire() <= 0;
     }
+
 }
 
 class ValidationRate {
@@ -267,6 +272,10 @@ class ValidationRate {
 
     public Duration getDelay() {
         return Duration.ofMillis((long)(1000*delay));
+    }
+
+    public boolean isStrained() {
+        return delay == DELAY_MAX;
     }
 
     public double getStrain() {

--- a/code/libraries/scrape-stopper/java/nu/marginalia/scrapestopper/ScrapeStopper.java
+++ b/code/libraries/scrape-stopper/java/nu/marginalia/scrapestopper/ScrapeStopper.java
@@ -175,14 +175,15 @@ class Token {
         if (!Objects.equals(remoteIp, this.remoteIp))
             return ScrapeStopper.TokenState.INVALID;
 
-        if (context != null && !Objects.equals(lastContext,context))
-            return ScrapeStopper.TokenState.INVALID;
-
         if (Instant.now().isBefore(validAfter))
             return ScrapeStopper.TokenState.EARLY;
 
         if (Instant.now().isAfter(validUntil))
             return ScrapeStopper.TokenState.INVALID;
+
+        // Short circuit
+        if (context != null && Objects.equals(lastContext,context))
+            return ScrapeStopper.TokenState.VALIDATED;
 
         var lastValidation = this.lastValidation;
 

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
@@ -93,8 +93,10 @@ public class SearchOperator {
                 cursor
         );
 
+        var asc = SearchResultRedirectService.createContext(ctx);
+
         List<UrlDetails> details = rs.results().stream()
-                .map(item -> createDetails(item, ctx))
+                .map(item -> createDetails(item, asc))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
@@ -114,8 +116,10 @@ public class SearchOperator {
                 cursor
         );
 
+        var asc = SearchResultRedirectService.createContext(ctx);
+
         List<UrlDetails> details = rs.results().stream()
-                .map(item -> createDetails(item, ctx))
+                .map(item -> createDetails(item, asc))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
@@ -134,8 +138,10 @@ public class SearchOperator {
                 cursor
         );
 
+        var asc = SearchResultRedirectService.createContext(ctx);
+
         List<UrlDetails> details = rs.results().stream()
-                .map(item -> createDetails(item, ctx))
+                .map(item -> createDetails(item, asc))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
@@ -209,12 +215,14 @@ public class SearchOperator {
         // Update the query count (this is what you see on the front page)
         searchVisitorCount.registerQuery();
 
+        var asc = SearchResultRedirectService.createContext(ctx);
+
         List<UrlDetails> details = queryResponse.results().stream()
                 .sorted(this::retentionSortOrder) // Sort in an order that makes us more likely to discard the "bad" duplicates
                 .filter(deduplicator::shouldRetain)
                 .sorted() // Return to the presentation sort order before limiting so we don't throw out good results over schema and "ip-ness"
                 .limit(limits.getResultsTotal())
-                .map(item -> createDetails(item, ctx))
+                .map(item -> createDetails(item, asc))
                 .toList();
 
         List<ResultsPage> pages = IntStream.rangeClosed(1, queryResponse.totalPages())
@@ -251,12 +259,12 @@ public class SearchOperator {
         return Double.compare(a.rankingScore, b.rankingScore);
     }
 
-    private UrlDetails createDetails(DecoratedSearchResultItem item, Context ctx) {
+    private UrlDetails createDetails(DecoratedSearchResultItem item, SearchResultRedirectService.AntiscrapeRedirContext asc) {
 
         String redirectUrl;
-        if (SearchResultRedirectService.isEnabled()) {
+        if (SearchResultRedirectService.isEnabled() && asc != null) {
             try {
-                redirectUrl = websiteUrl.withPath(SearchResultRedirectService.encode(ctx, item.rawIndexResult.nodeId, item.rawIndexResult.getDocumentId()));
+                redirectUrl = websiteUrl.withPath(SearchResultRedirectService.encode(asc, item.rawIndexResult.nodeId, item.rawIndexResult.getDocumentId()));
             }
             catch (Exception ex) {
                 logger.error("Error encoding redirect URL", ex);

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchOperator.java
@@ -2,7 +2,9 @@ package nu.marginalia.search;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.jooby.Context;
 import it.unimi.dsi.fastutil.ints.IntList;
+import nu.marginalia.WebsiteUrl;
 import nu.marginalia.api.math.MathClient;
 import nu.marginalia.api.searchquery.QueryClient;
 import nu.marginalia.api.searchquery.RpcQueryLimits;
@@ -18,6 +20,7 @@ import nu.marginalia.model.crawl.DomainIndexingState;
 import nu.marginalia.search.model.*;
 import nu.marginalia.search.results.UrlDeduplicator;
 import nu.marginalia.search.svc.SearchQueryCountService;
+import nu.marginalia.search.svc.SearchResultRedirectService;
 import nu.marginalia.search.svc.SearchUnitConversionService;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
@@ -50,6 +53,7 @@ public class SearchOperator {
     private final QueryClient queryClient;
     private final SearchUnitConversionService searchUnitConversionService;
     private final SearchQueryCountService searchVisitorCount;
+    private final WebsiteUrl websiteUrl;
 
     static final RpcQueryLimits defaultLimits = RpcQueryLimits.newBuilder()
             .setResultsTotal(100)
@@ -62,7 +66,8 @@ public class SearchOperator {
                           DbDomainQueries domainQueries,
                           QueryClient queryClient,
                           SearchUnitConversionService searchUnitConversionService,
-                          SearchQueryCountService searchVisitorCount
+                          SearchQueryCountService searchVisitorCount,
+                          WebsiteUrl websiteUrl
                           )
     {
 
@@ -71,9 +76,12 @@ public class SearchOperator {
         this.queryClient = queryClient;
         this.searchUnitConversionService = searchUnitConversionService;
         this.searchVisitorCount = searchVisitorCount;
+        this.websiteUrl = websiteUrl;
     }
 
-    public UnrankedSearchResults doSiteSearch(String domain, int count, String cursor) throws TimeoutException {
+    public UnrankedSearchResults doSiteSearch(
+            Context ctx,
+            String domain, int count, String cursor) throws TimeoutException {
 
         var rs =  queryClient.unrankedSearch(
                 List.of("site:"+domain),
@@ -86,13 +94,15 @@ public class SearchOperator {
         );
 
         List<UrlDetails> details = rs.results().stream()
-                .map(SearchOperator::createDetails)
+                .map(item -> createDetails(item, ctx))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
     }
 
-    public UnrankedSearchResults doBacklinkSearch(String domain, String cursor) throws TimeoutException {
+    public UnrankedSearchResults doBacklinkSearch(
+            Context ctx,
+            String domain, String cursor) throws TimeoutException {
 
         var rs =  queryClient.unrankedSearch(
                 List.of("links:"+domain),
@@ -105,13 +115,14 @@ public class SearchOperator {
         );
 
         List<UrlDetails> details = rs.results().stream()
-                .map(SearchOperator::createDetails)
+                .map(item -> createDetails(item, ctx))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
     }
 
-    public UnrankedSearchResults doLinkSearch(String source, String dest, String cursor) throws TimeoutException {
+    public UnrankedSearchResults doLinkSearch(Context ctx,
+                                              String source, String dest, String cursor) throws TimeoutException {
 
         var rs =  queryClient.unrankedSearch(
                 List.of("site:"+source, "links:"+dest),
@@ -124,13 +135,13 @@ public class SearchOperator {
         );
 
         List<UrlDetails> details = rs.results().stream()
-                .map(SearchOperator::createDetails)
+                .map(item -> createDetails(item, ctx))
                 .toList();
 
         return new UnrankedSearchResults(details, rs.encodedCursor());
     }
 
-    public DecoratedSearchResults doSearch(SearchParameters userParams) throws InterruptedException, TimeoutException {
+    public DecoratedSearchResults doSearch(Context ctx, SearchParameters userParams) throws InterruptedException, TimeoutException {
         // The full user-facing search query does additional work to try to evaluate the query
         // e.g. as a unit conversion query. This is done in parallel with the regular search.
 
@@ -147,7 +158,7 @@ public class SearchOperator {
                 userParams.page()
                 );
 
-        var queryResults = getResultsFromQuery(queryResponse).results;
+        var queryResults = getResultsFromQuery(ctx, queryResponse).results;
 
         // Cluster the results based on the query response
         List<ClusteredUrlDetails> clusteredResults = SearchResultClusterer
@@ -191,7 +202,7 @@ public class SearchOperator {
                 .build();
     }
 
-    public SimpleSearchResults getResultsFromQuery(QueryResponse queryResponse) {
+    public SimpleSearchResults getResultsFromQuery(Context ctx, QueryResponse queryResponse) {
         final RpcQueryLimits limits = queryResponse.limits();
         final UrlDeduplicator deduplicator = new UrlDeduplicator(limits.getResultsByDomain());
 
@@ -203,7 +214,7 @@ public class SearchOperator {
                 .filter(deduplicator::shouldRetain)
                 .sorted() // Return to the presentation sort order before limiting so we don't throw out good results over schema and "ip-ness"
                 .limit(limits.getResultsTotal())
-                .map(SearchOperator::createDetails)
+                .map(item -> createDetails(item, ctx))
                 .toList();
 
         List<ResultsPage> pages = IntStream.rangeClosed(1, queryResponse.totalPages())
@@ -240,11 +251,27 @@ public class SearchOperator {
         return Double.compare(a.rankingScore, b.rankingScore);
     }
 
-    private static UrlDetails createDetails(DecoratedSearchResultItem item) {
+    private UrlDetails createDetails(DecoratedSearchResultItem item, Context ctx) {
+
+        String redirectUrl;
+        if (SearchResultRedirectService.isEnabled()) {
+            try {
+                redirectUrl = websiteUrl.withPath(SearchResultRedirectService.encode(ctx, item.rawIndexResult.nodeId, item.rawIndexResult.getDocumentId()));
+            }
+            catch (Exception ex) {
+                logger.error("Error encoding redirect URL", ex);
+                redirectUrl = null;
+            }
+        }
+        else {
+            redirectUrl = null;
+        }
+
         return new UrlDetails(
                 item.documentId(),
                 item.domainId(),
                 cleanUrl(item.url),
+                redirectUrl,
                 item.title,
                 item.description,
                 item.format,

--- a/code/services-application/search-service/java/nu/marginalia/search/SearchService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/SearchService.java
@@ -55,12 +55,14 @@ public class SearchService extends JoobyService {
                          FaviconClient faviconClient,
                          DbDomainQueries domainQueries,
                          SearchFilterService searchFilterService,
+                         SearchResultRedirectService resultRedirectService,
                          SearchQueryService searchQueryService)
     throws Exception {
         super(params,
                 List.of(), // No GRPC services
                 List.of(new SearchFrontPageService_(frontPageService),
                         new SearchQueryService_(searchQueryService),
+                        new SearchResultRedirectService_(resultRedirectService),
                         new SearchSiteInfoService_(siteInfoService),
                         new SearchCrosstalkService_(crosstalkService),
                         new SearchAddToCrawlQueueService_(addToCrawlQueueService),

--- a/code/services-application/search-service/java/nu/marginalia/search/command/SearchCommand.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/command/SearchCommand.java
@@ -40,7 +40,7 @@ public class SearchCommand implements SearchCommandInterface {
                     )
             ));
         } else {
-            results = searchOperator.doSearch(parameters);
+            results = searchOperator.doSearch(ctx, parameters);
             return Optional.of(new MapModelAndView("serp/main.jte",
                     Map.of("results", results,
                             "navbar", NavbarModel.SEARCH,

--- a/code/services-application/search-service/java/nu/marginalia/search/model/ClusteredUrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/ClusteredUrlDetails.java
@@ -89,7 +89,7 @@ public class ClusteredUrlDetails implements Comparable<ClusteredUrlDetails> {
 
 
     public EdgeDomain getDomain() {
-        return first.url.getDomain();
+        return first.getUrl().getDomain();
     }
 
     public boolean hasMultiple() {

--- a/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/model/UrlDetails.java
@@ -7,6 +7,7 @@ import nu.marginalia.model.crawl.DomainIndexingState;
 import nu.marginalia.model.crawl.HtmlFeature;
 import nu.marginalia.model.crawl.PubDate;
 import nu.marginalia.model.idx.DocumentMetadata;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -20,7 +21,10 @@ public class UrlDetails implements Comparable<UrlDetails> {
     public long id;
     public int domainId;
 
-    public EdgeUrl url;
+    private EdgeUrl url;
+    @Nullable
+    public String redirUrl;
+
     public String title;
     public String description;
 
@@ -44,10 +48,27 @@ public class UrlDetails implements Comparable<UrlDetails> {
 
     private static final DateTimeFormatter DISPLAY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    public UrlDetails(long id, int domainId, EdgeUrl url, String title, String description, String format, int features, DomainIndexingState domainState, double termScore, int resultsFromSameDomain, int pubDate, String positions, long positionsMask, int positionsCount, SearchResultItem resultItem, List<SearchResultKeywordScore> keywordScores) {
+    public UrlDetails(long id,
+                      int domainId,
+                      EdgeUrl url,
+                      String redirUrl,
+                      String title,
+                      String description,
+                      String format,
+                      int features,
+                      DomainIndexingState domainState,
+                      double termScore,
+                      int resultsFromSameDomain,
+                      int pubDate,
+                      String positions,
+                      long positionsMask,
+                      int positionsCount,
+                      SearchResultItem resultItem,
+                      List<SearchResultKeywordScore> keywordScores) {
         this.id = id;
         this.domainId = domainId;
         this.url = url;
+        this.redirUrl = redirUrl;
         this.title = title;
         this.description = description;
         this.format = format;
@@ -220,7 +241,15 @@ public class UrlDetails implements Comparable<UrlDetails> {
      * semantically meaningful codepoints into entity codes */
     public String displayUrl() {
         StringBuilder sb = new StringBuilder();
-        String urlStr = url.toDisplayString();
+        String urlStr;
+
+        if (redirUrl != null) {
+            urlStr = url.withPathAndParam("/", null).toDisplayString();
+        }
+        else {
+            urlStr = url.toDisplayString();
+        }
+
         for (int i = 0; i < urlStr.length(); i++) {
             char c = urlStr.charAt(i);
 
@@ -243,6 +272,13 @@ public class UrlDetails implements Comparable<UrlDetails> {
         }
 
         return sb.toString();
+    }
+
+    public String userFacingUrl() {
+        if (redirUrl != null) {
+            return redirUrl;
+        }
+        return url.toString();
     }
 
     @Override

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchCrosstalkService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchCrosstalkService.java
@@ -75,8 +75,8 @@ public class SearchCrosstalkService {
             parts[i] = parts[i].trim();
         }
 
-        UnrankedSearchResults resAtoB = searchOperator.doLinkSearch(parts[0], parts[1], cursorA);
-        UnrankedSearchResults resBtoA = searchOperator.doLinkSearch(parts[1], parts[0], cursorB);
+        UnrankedSearchResults resAtoB = searchOperator.doLinkSearch(context, parts[0], parts[1], cursorA);
+        UnrankedSearchResults resBtoA = searchOperator.doLinkSearch(context, parts[1], parts[0], cursorB);
 
         CrosstalkResult model = new CrosstalkResult(
                 interceptResult.sst(),

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
@@ -7,6 +7,7 @@ import io.jooby.MapModelAndView;
 import io.jooby.StatusCode;
 import io.jooby.annotation.*;
 import nu.marginalia.api.searchquery.IndexUrlClient;
+import nu.marginalia.scrapestopper.ScrapeStopper;
 import nu.marginalia.search.model.NavbarModel;
 
 import java.security.MessageDigest;
@@ -15,7 +16,9 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -25,15 +28,26 @@ public class SearchResultRedirectService {
     private static final String salt = Long.toUnsignedString(ThreadLocalRandom.current().nextLong(), 36);
 
     private final IndexUrlClient urlClient;
+    private final ScrapeStopper scrapeStopper;
+
+    private static volatile boolean isEnabled = false;
 
     @Inject
-    public SearchResultRedirectService(IndexUrlClient urlClient) {
+    public SearchResultRedirectService(IndexUrlClient urlClient,
+                                       ScrapeStopper scrapeStopper) {
         this.urlClient = urlClient;
+        this.scrapeStopper = scrapeStopper;
+
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                () -> isEnabled = scrapeStopper.isStrained(),
+                60,
+                60,
+                TimeUnit.SECONDS
+        );
     }
 
     public static boolean isEnabled() {
-        // FIXME:  Trigger on rate limit
-        return true;
+        return isEnabled;
     }
 
     @GET
@@ -46,6 +60,9 @@ public class SearchResultRedirectService {
             throws TimeoutException
     {
         String ip = context.header(realIpHeader).valueOrNull();
+        if (ip == null) {
+            ip = context.getRemoteAddress();
+        }
 
         var urlLookup = urlClient.getUrl(node, docid);
         if (urlLookup.isEmpty()) {
@@ -105,6 +122,11 @@ public class SearchResultRedirectService {
                 .append(Long.toUnsignedString(docId))
                 .append('/')
                 .append(time);
+
+        long timeDecoded = Long.parseUnsignedLong(time, 36);
+        if (timeDecoded > System.currentTimeMillis() - 3600) {
+            return false;
+        }
 
         try {
             MessageDigest hasher = MessageDigest.getInstance("SHA-256");

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
@@ -1,0 +1,123 @@
+package nu.marginalia.search.svc;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.jooby.Context;
+import io.jooby.MapModelAndView;
+import io.jooby.StatusCode;
+import io.jooby.annotation.*;
+import nu.marginalia.api.searchquery.IndexUrlClient;
+import nu.marginalia.search.model.NavbarModel;
+
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Singleton
+public class SearchResultRedirectService {
+    private static final String realIpHeader = System.getProperty("system.realIpHeader", "X-Forwarded-For");
+    private static final String salt = Long.toUnsignedString(ThreadLocalRandom.current().nextLong(), 36);
+
+    private final IndexUrlClient urlClient;
+
+    @Inject
+    public SearchResultRedirectService(IndexUrlClient urlClient) {
+        this.urlClient = urlClient;
+    }
+
+    public static boolean isEnabled() {
+        // FIXME:  Trigger on rate limit
+        return true;
+    }
+
+    @GET
+    @Path("/r/{node}/{docid}/{ts}")
+    public MapModelAndView redirectToSite(Context context,
+                                          @PathParam int node,
+                                          @PathParam long docid,
+                                          @PathParam String ts,
+                                          @QueryParam String hash)
+            throws TimeoutException
+    {
+        String ip = context.header(realIpHeader).valueOrNull();
+
+        var urlLookup = urlClient.getUrl(node, docid);
+        if (urlLookup.isEmpty()) {
+            context.setResponseCode(404);
+            return null;
+        }
+
+        if (validateUrl(hash, ip, ts, node, docid)) {
+            context.sendRedirect(StatusCode.TEMPORARY_REDIRECT, urlLookup.get());
+            return null;
+        }
+
+        context.setResponseHeader("Cache-Control", "no-store");
+
+        return new MapModelAndView("serp/extredirwait.jte",
+                Map.of(
+                        "waitDuration", Duration.ofSeconds(5),
+                        "navbar", NavbarModel.SEARCH,
+                        "redirUrl", urlLookup.get()
+                )
+        );
+    }
+    public static String encode(Context ctx, int node, long docId) {
+        String ip = ctx.header(realIpHeader).valueOrNull();
+        long time = System.currentTimeMillis();
+
+        return encode(ip, time, node, docId);
+    }
+
+    public static String encode(String remoteIp, long time, int node, long docId) {
+
+        var sj = new StringJoiner("/", "r/", "");
+
+        sj.add(Integer.toString(node));
+        sj.add(Long.toUnsignedString(docId));
+        sj.add(Long.toUnsignedString(time,36));
+
+        try {
+            MessageDigest hasher = MessageDigest.getInstance("SHA-256");
+            hasher.update(salt.getBytes());
+            hasher.update(remoteIp.getBytes());
+            hasher.update(sj.toString().getBytes());
+
+            return sj.toString() + "?hash="+ Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean validateUrl(String providedHash, String remoteIp, String time, int node, long docId) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("r/")
+                .append(Integer.toString(node))
+                .append('/')
+                .append(Long.toUnsignedString(docId))
+                .append('/')
+                .append(time);
+
+        try {
+            MessageDigest hasher = MessageDigest.getInstance("SHA-256");
+
+            hasher.update(salt.getBytes());
+            hasher.update(remoteIp.getBytes());
+            hasher.update(sb.toString().getBytes());
+
+            return Objects.equals(providedHash, Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest()));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
@@ -19,12 +19,7 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
-import java.util.StringJoiner;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Singleton
@@ -131,19 +126,25 @@ public class SearchResultRedirectService {
 
     public static String encode(AntiscrapeRedirContext context, int node, long docId) {
 
-        var sj = new StringJoiner("/", "r/", "");
+        StringBuilder sb = new StringBuilder();
 
-        sj.add(Integer.toString(node));
-        sj.add(Long.toUnsignedString(docId));
-        sj.add(Long.toUnsignedString(context.ts,36));
+        sb.append("r/")
+                .append(Integer.toString(node))
+                .append('/')
+                .append(Long.toUnsignedString(docId))
+                .append('/')
+                .append(Long.toUnsignedString(context.ts,36));
 
         try {
             MessageDigest hasher = MessageDigest.getInstance("SHA-256");
             hasher.update(salt.getBytes());
             hasher.update(context.ip.getBytes());
-            hasher.update(sj.toString().getBytes());
+            hasher.update(sb.toString().getBytes());
 
-            return sj.toString() + "?hash="+ Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest());
+            return sb
+                    .append("?hash=")
+                    .append(Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest()))
+                    .toString();
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchResultRedirectService.java
@@ -5,10 +5,14 @@ import com.google.inject.Singleton;
 import io.jooby.Context;
 import io.jooby.MapModelAndView;
 import io.jooby.StatusCode;
-import io.jooby.annotation.*;
+import io.jooby.annotation.GET;
+import io.jooby.annotation.Path;
+import io.jooby.annotation.PathParam;
+import io.jooby.annotation.QueryParam;
 import nu.marginalia.api.searchquery.IndexUrlClient;
 import nu.marginalia.scrapestopper.ScrapeStopper;
 import nu.marginalia.search.model.NavbarModel;
+import org.jetbrains.annotations.Nullable;
 
 import java.security.MessageDigest;
 import java.time.Duration;
@@ -16,16 +20,20 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Singleton
 public class SearchResultRedirectService {
     private static final String realIpHeader = System.getProperty("system.realIpHeader", "X-Forwarded-For");
     private static final String salt = Long.toUnsignedString(ThreadLocalRandom.current().nextLong(), 36);
+
+    private static final ConcurrentHashMap<Long, Long> lastVisit = new ConcurrentHashMap<>();
+    private static final AtomicLong timeCt = new AtomicLong();
 
     private final IndexUrlClient urlClient;
     private final ScrapeStopper scrapeStopper;
@@ -38,9 +46,14 @@ public class SearchResultRedirectService {
         this.urlClient = urlClient;
         this.scrapeStopper = scrapeStopper;
 
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                () -> isEnabled = scrapeStopper.isStrained(),
-                60,
+        Executors.newSingleThreadScheduledExecutor(
+                Thread.ofPlatform().name("result-redirect-maintenance").daemon().factory()
+        ).scheduleAtFixedRate(
+                () -> {
+                    isEnabled = scrapeStopper.isStrained();
+                    lastVisit.entrySet().removeIf(e -> System.nanoTime() - e.getValue()  > 30_000_000_000L);
+                },
+                0,
                 60,
                 TimeUnit.SECONDS
         );
@@ -49,6 +62,39 @@ public class SearchResultRedirectService {
     public static boolean isEnabled() {
         return isEnabled;
     }
+
+    @Nullable
+    public static AntiscrapeRedirContext createContext(Context ctx) {
+        if (!isEnabled()) {
+            return null;
+        }
+        return new AntiscrapeRedirContext(ctx);
+    }
+
+    public record AntiscrapeRedirContext(long ts, String ip) {
+        public AntiscrapeRedirContext(Context ctx) {
+            this(acquireTimestamp(), resolveIp(ctx));
+        }
+    }
+
+    private static String resolveIp(Context ctx) {
+        return ctx.header(realIpHeader).value(ctx.getRemoteAddress());
+    }
+
+    private static long acquireTimestamp() {
+        for (;;) {
+            long prevTime = timeCt.get();
+            long now = System.nanoTime();
+
+            if (prevTime >= now) {
+                now = prevTime + 1;
+            }
+            if (timeCt.compareAndSet(prevTime, now)) {
+                return now;
+            }
+        }
+    }
+
 
     @GET
     @Path("/r/{node}/{docid}/{ts}")
@@ -59,10 +105,7 @@ public class SearchResultRedirectService {
                                           @QueryParam String hash)
             throws TimeoutException
     {
-        String ip = context.header(realIpHeader).valueOrNull();
-        if (ip == null) {
-            ip = context.getRemoteAddress();
-        }
+        String ip = resolveIp(context);
 
         var urlLookup = urlClient.getUrl(node, docid);
         if (urlLookup.isEmpty()) {
@@ -85,25 +128,19 @@ public class SearchResultRedirectService {
                 )
         );
     }
-    public static String encode(Context ctx, int node, long docId) {
-        String ip = ctx.header(realIpHeader).valueOrNull();
-        long time = System.currentTimeMillis();
 
-        return encode(ip, time, node, docId);
-    }
-
-    public static String encode(String remoteIp, long time, int node, long docId) {
+    public static String encode(AntiscrapeRedirContext context, int node, long docId) {
 
         var sj = new StringJoiner("/", "r/", "");
 
         sj.add(Integer.toString(node));
         sj.add(Long.toUnsignedString(docId));
-        sj.add(Long.toUnsignedString(time,36));
+        sj.add(Long.toUnsignedString(context.ts,36));
 
         try {
             MessageDigest hasher = MessageDigest.getInstance("SHA-256");
             hasher.update(salt.getBytes());
-            hasher.update(remoteIp.getBytes());
+            hasher.update(context.ip.getBytes());
             hasher.update(sj.toString().getBytes());
 
             return sj.toString() + "?hash="+ Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest());
@@ -123,11 +160,6 @@ public class SearchResultRedirectService {
                 .append('/')
                 .append(time);
 
-        long timeDecoded = Long.parseUnsignedLong(time, 36);
-        if (timeDecoded > System.currentTimeMillis() - 3600) {
-            return false;
-        }
-
         try {
             MessageDigest hasher = MessageDigest.getInstance("SHA-256");
 
@@ -135,11 +167,29 @@ public class SearchResultRedirectService {
             hasher.update(remoteIp.getBytes());
             hasher.update(sb.toString().getBytes());
 
-            return Objects.equals(providedHash, Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest()));
+            if (!Objects.equals(providedHash, Base64.getUrlEncoder().withoutPadding().encodeToString(hasher.digest()))) {
+                return false;
+            }
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+
+        // Stale URL, older than 15 minutes
+        long timeDecoded = Long.parseUnsignedLong(time, 36);
+        if (System.nanoTime() - timeDecoded > 15*60*1000_000_000L) {
+            return false;
+        }
+
+        // All links on a result page share a timestamp, so this trips when more than one
+        // result from the same page is followed within a second.  It's not *impossible* to hit as a human,
+        // but a bigger headache when you're a scraper
+        Long lastVisitTime = lastVisit.put(timeDecoded, System.nanoTime());
+        if (lastVisitTime != null && System.nanoTime() - lastVisitTime < 1000_000_000L) {
+            return false;
+        }
+
+        return true;
     }
 }
 

--- a/code/services-application/search-service/java/nu/marginalia/search/svc/SearchSiteInfoService.java
+++ b/code/services-application/search-service/java/nu/marginalia/search/svc/SearchSiteInfoService.java
@@ -223,8 +223,8 @@ public class SearchSiteInfoService {
         String sst = interceptResult.sst();
 
         SiteInfoModel model = switch (view) {
-            case "links" -> listLinks(domainName, sst, cursor);
-            case "docs" -> listDocs(domainName, sst, cursor);
+            case "links" -> listLinks(context, domainName, sst, cursor);
+            case "docs" -> listDocs(context, domainName, sst, cursor);
             case "info" -> listInfo(context, domainName, sst);
             case "traffic" -> listSiteRequests(context, domainName, sst);
             case "availability" -> listAvailabilityEvents(context, domainName, sst);
@@ -320,8 +320,8 @@ public class SearchSiteInfoService {
     }
 
 
-    private Backlinks listLinks(String domainName, String sst, String cursor) throws TimeoutException {
-        var results = searchOperator.doBacklinkSearch(domainName, cursor);
+    private Backlinks listLinks(Context ctx, String domainName, String sst, String cursor) throws TimeoutException {
+        var results = searchOperator.doBacklinkSearch(ctx, domainName, cursor);
 
         return new Backlinks(domainName,
                 sst,
@@ -379,11 +379,11 @@ public class SearchSiteInfoService {
             sampleResults = List.of();
         }
         else {
-            sampleResults = searchOperator.doSiteSearch(domainName, 5, "").results;
+            sampleResults = searchOperator.doSiteSearch(context, domainName, 5, "").results;
         }
 
         if (!sampleResults.isEmpty()) {
-            url = sampleResults.getFirst().url.withPathAndParam("/", null).toString();
+            url = sampleResults.getFirst().getUrl().withPathAndParam("/", null).toString();
         }
 
 
@@ -476,9 +476,9 @@ public class SearchSiteInfoService {
                 .build();
     }
 
-    private Docs listDocs(String domainName, String sst, String cursor) throws TimeoutException {
+    private Docs listDocs(Context ctx, String domainName, String sst, String cursor) throws TimeoutException {
         int domainId = domainQueries.tryGetDomainId(new EdgeDomain(domainName)).orElse(-1);
-        var results = searchOperator.doSiteSearch(domainName, 100, cursor);
+        var results = searchOperator.doSiteSearch(ctx, domainName, 100, cursor);
 
         return new Docs(domainName,
                 sst,

--- a/code/services-application/search-service/resources/jte/serp/extredirwait.jte
+++ b/code/services-application/search-service/resources/jte/serp/extredirwait.jte
@@ -1,0 +1,63 @@
+@import nu.marginalia.search.model.NavbarModel
+@import nu.marginalia.search.model.UrlDetails
+@import nu.marginalia.model.EdgeDomain
+@import nu.marginalia.search.svc.*
+@import java.time.Duration
+
+@param NavbarModel navbar
+@param Duration waitDuration
+@param String redirUrl
+
+<!DOCTYPE html>
+<html lang="en">
+
+@template.part.head(title = "One Moment - Marginalia Search")
+
+<body class="min-h-screen bg-bgblue dark:bg-gray-900 dark:text-white font-sans " >
+
+<a class="sr-only" href="skipnav">Skip To Content</a>
+@template.part.navbar(navbar = navbar)
+
+<div id="skipnav"></div>
+
+
+<div class="max-w-[1000px] mx-auto flex gap-1 flex-col md:flex-row place-items-center md:place-items-start py-4 basis-1/2">
+    <div class="border dark:border-gray-600 rounded flex flex-col space-x-4 bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-100 text-sm p-4 items-center">
+
+        <div class="flex flex-row gap-2 place-items-center">
+            <i class="fas fa-clock text-2xl animate-pulse"></i>
+            <h1 class="font-bold text-2xl">Wait A Moment</h1>
+        </div>
+
+        <div>
+            You've run into the Marginalia Search anti-scraper measures.  Wait a few seconds before you're redirected
+            to the search result.  This is a regrettable necessity for operating the search engine on a single server.
+            Unless there's a bug or you're being very naughty, you should never see this screen.
+        </div>
+        <div>
+            Please wait for <span class="font-bold" data-tr="${1+waitDuration.getSeconds()}" id="countdown">${1+waitDuration.getSeconds()}</span> seconds before proceeding.
+        </div>
+
+        <noscript class="my-2">
+            Click <a role="button" href="${redirUrl}" class="underline">here</a> to proceed manually if javascript is disabled.
+        </noscript>
+
+        <script>
+            window.setInterval(()=>{
+                const cd = document.getElementById('countdown');
+                var tr = cd.getAttribute('data-tr');
+                tr--;
+                cd.setAttribute('data-tr', tr);
+                cd.innerHTML=tr;
+            }, 1000);
+
+            window.setTimeout(()=> { location.replace('${redirUrl}'); }, ${waitDuration.toMillis()});
+        </script>
+    </div>
+</div>
+
+
+@template.part.footerLegal()
+
+</body>
+</html>

--- a/code/services-application/search-service/resources/jte/serp/part/result.jte
+++ b/code/services-application/search-service/resources/jte/serp/part/result.jte
@@ -13,12 +13,12 @@
             <div class="flex flex-col grow" >
                 <div class="flex flex-row space-x-2 place-items-center">
                     <div class="flex-0" title="Match density">
-                        @template.serp.part.matchogram(mask = result.first.positionsMask, domain=result.getFirst().url.domain.toString())
+                        @template.serp.part.matchogram(mask = result.first.positionsMask, domain=result.getFirst().getUrl().domain.toString())
                     </div>
                     <div class="flex grow justify-between items-start">
                         <div class="flex-1">
                             <h2 class="text-md sm:text-xl ${result.colorScheme.textColor} font-serif mr-4 break-words hyphens-auto">
-                                <a href="${result.first.url.toString()}" rel="noopener noreferrer" dir="auto">$unsafe{result.first.displayTitle()}</a>
+                                <a href="${result.first.userFacingUrl()}" rel="noopener noreferrer" dir="auto">$unsafe{result.first.displayTitle()}</a>
                             </h2>
 
                             <div class="text-sm mt-1">
@@ -29,7 +29,7 @@
                                 @if ("PDF".equals(result.first.format))
                                     <i title="PDF" class="fas fa-file-pdf text-red-500"></i>
                                 @endif
-                                <a class="text-liteblue dark:text-blue-200 underline break-all" href="${result.first.url.toString()}"
+                                <a class="text-liteblue dark:text-blue-200 underline break-all" href="${result.first.userFacingUrl()}"
                                    rel="noopener noreferrer" tabindex="-1">$unsafe{result.first.displayUrl()}</a>
                             </div>
                         </div>
@@ -49,7 +49,7 @@
                     <a href="/site/${result.getDomain().toString()}" class="p-1.5 dark:text-gray-200 dark:hover:text-gray-400 text-gray-600 hover:text-gray-900 rounded-xl active:outline outline-1 outline-margeblue" title="About this domain">
                         <i class="fas fa-info text-sm"></i>
                     </a>
-                    <a href="https://web.archive.org/web/*/${result.first.url.toString()}"
+                    <a href="https://web.archive.org/web/*/${result.first.userFacingUrl()}"
                        class="p-1.5 dark:text-gray-200 dark:hover:text-gray-400 text-gray-600 hover:text-gray-900 rounded-xl active:outline outline-1 outline-margeblue"
                        title="Wayback Machine">
                         <i class="fas fa-clock-rotate-left text-sm"></i>
@@ -67,7 +67,7 @@
                             @if ("PDF".equals(item.format))
                                 <i title="PDF" class="fas fa-file-pdf text-red-500"></i>
                             @endif
-                            <a href="${item.url.toString()}" class="underline" rel="noopener noreferrer" dir="auto">$unsafe{item.displayTitle()}</a>
+                            <a href="${item.userFacingUrl()}" class="underline" rel="noopener noreferrer" dir="auto">$unsafe{item.displayTitle()}</a>
                         </li>
                     @endfor
                 </ul>

--- a/code/services-application/search-service/resources/jte/siteinfo/crosstalk.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/crosstalk.jte
@@ -73,7 +73,7 @@
                 $unsafe{details.displayDescription()}
             </div>
             <div class="p-2 text-sm border-b dark:border-gray-600 pb-6">
-                <a rel="external noopener nofollow" href="${details.url.toString()}" class="mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
+                <a rel="external noopener nofollow" href="${details.userFacingUrl().toString()}" class="mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
                     <i class="fa fa-link"></i>
                     <span class="grow break-all">$unsafe{details.displayUrl()}</span>
                 </a>
@@ -97,7 +97,7 @@
                 $unsafe{details.displayDescription()}
             </div>
             <div class="p-2 text-sm border-b dark:border-gray-600 pb-6">
-                <a rel="external noopener nofollow" href="${details.url.toString()}" class="mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
+                <a rel="external noopener nofollow" href="${details.userFacingUrl().toString()}" class="mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
                     <i class="fa fa-link"></i>
                     <span class="grow break-all">$unsafe{details.displayUrl()}</span>
                 </a>

--- a/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/backlinks.jte
@@ -32,7 +32,7 @@
             $unsafe{details.displayDescription()}
         </div>
         <div class="p-2 text-sm border-b dark:border-gray-600 pb-6">
-            <a rel="external noopener nofollow" href="${details.url.toString()}" class="underline mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
+            <a rel="external noopener nofollow" href="${details.userFacingUrl().toString()}" class="underline mx-3 text-liteblue dark:text-blue-200 flex space-x-2 place-items-baseline hyphens-auto">
                 <i class="fa fa-link"></i>
                 <span class="grow break-all">$unsafe{details.displayUrl()}</span>
             </a>

--- a/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/docs.jte
@@ -23,10 +23,10 @@
     <div class="flex grow justify-between items-start p-4">
         <div class="flex-1">
             <h2 class="text-xl text-gray-800 dark:text-white font-serif mr-4">
-                <a href="${details.url.toString()}" rel="noopener noreferrer">$unsafe{details.displayTitle()}</a>
+                <a href="${details.userFacingUrl().toString()}" rel="noopener noreferrer">$unsafe{details.displayTitle()}</a>
             </h2>
             <div class="text-sm mt-1 text-slate-800">
-                <a class="text-liteblue dark:text-blue-200 underline break-all" href="${details.url.toString()}"
+                <a class="text-liteblue dark:text-blue-200 underline break-all" href="${details.userFacingUrl().toString()}"
                    rel="noopener noreferrer" tabindex="-1">$unsafe{details.displayUrl()}</a>
             </div>
         </div>

--- a/code/services-application/search-service/resources/jte/siteinfo/view/overview.jte
+++ b/code/services-application/search-service/resources/jte/siteinfo/view/overview.jte
@@ -120,7 +120,7 @@
             <dl class="mx-3 text-gray-800 dark:text-white">
                 @for (UrlDetails item : siteInfo.samples())
                     <dt class="ml-2">
-                        <a class="underline text-liteblue dark:text-blue-200 text-sm" rel="noopener nofollow external ugc" href="${item.url.toString()}">${item.title}</a>
+                        <a class="underline text-liteblue dark:text-blue-200 text-sm" rel="noopener nofollow external ugc" href="${item.userFacingUrl().toString()}">${item.title}</a>
                     </dt>
                     <dd class="ml-6 text-sm mb-4">${item.description}</dd>
                 @endfor

--- a/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
+++ b/code/services-application/search-service/test/nu/marginalia/search/rendering/MockedSearchResults.java
@@ -46,6 +46,7 @@ public class MockedSearchResults {
                 1,
                 1,
                 new EdgeUrl(url),
+                null,
                 title,
                 desc,
                 "HTML5",
@@ -57,7 +58,7 @@ public class MockedSearchResults {
                 "",
                 mockPositionsMask(),
                 2,
-                new SearchResultItem(0, 0, 0, 0, 0),
+                new SearchResultItem(0, 1, 0, 0, 0, 0),
                 null);
 
     }

--- a/code/services-core/index-service/java/nu/marginalia/index/IndexService.java
+++ b/code/services-core/index-service/java/nu/marginalia/index/IndexService.java
@@ -17,7 +17,6 @@ import nu.marginalia.linkgraph.PartitionLinkGraphService;
 import nu.marginalia.livecapture.LiveCaptureGrpcService;
 import nu.marginalia.rss.svc.FeedsGrpcService;
 import nu.marginalia.service.control.ServiceEventLog;
-import nu.marginalia.service.discovery.property.ServicePartition;
 import nu.marginalia.service.server.BaseServiceParams;
 import nu.marginalia.service.server.Initialization;
 import nu.marginalia.service.server.JoobyService;
@@ -57,6 +56,7 @@ public class IndexService extends JoobyService {
     public IndexService(BaseServiceParams params,
                         IndexOpsService opsService,
                         IndexGrpcService indexQueryService,
+                        IndexUrlApiGrpcService urlApiService,
                         StatefulIndex statefulIndex,
                         SearchSetsService searchSetsService,
                         ConnectivitySets connectivitySets,
@@ -79,6 +79,7 @@ public class IndexService extends JoobyService {
     {
         super(params,
                 List.of(indexQueryService,
+                        urlApiService,
                         partitionLinkGraphService,
                         liveCaptureGrpcService,
                         domSampleGrpcService,

--- a/code/tools/integration-test/test/nu/marginalia/IntegrationTest.java
+++ b/code/tools/integration-test/test/nu/marginalia/IntegrationTest.java
@@ -246,7 +246,7 @@ public class IntegrationTest {
             System.out.println(query);
 
             var rs = new IndexQueryExecution(indexReference.get(), documentDbReader, rankingService,
-                    SearchContext.create(indexReference.get(), new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
+                    SearchContext.create(indexReference.get(), 1, new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
 
             System.out.println(rs);
             Assertions.assertEquals(1, rs.size());
@@ -268,7 +268,7 @@ public class IntegrationTest {
             System.out.println(query);
 
             var rs = new IndexQueryExecution(indexReference.get(), documentDbReader, rankingService,
-                    SearchContext.create(indexReference.get(), new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
+                    SearchContext.create(indexReference.get(), 1, new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
 
             System.out.println(rs);
             Assertions.assertEquals(1, rs.size());
@@ -379,7 +379,7 @@ public class IntegrationTest {
 
 //            System.out.println(query);
 
-            var rs = new IndexQueryExecution(indexReference.get(), documentDbReader, rankingService, SearchContext.create(indexReference.get(), new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
+            var rs = new IndexQueryExecution(indexReference.get(), documentDbReader, rankingService, SearchContext.create(indexReference.get(), 1, new KeywordHasher.AsciiIsh(), query.indexQuery, new SearchSetAny(), ConnectivityView.empty()), 1).run();
 
             System.out.println(rs);
 


### PR DESCRIPTION
The search engine has been under extreme pressure from bots the last 24 hours, seeing peaks of up to 60 QPS, with sustained loads hovering around 10-20 QPS for marginalia-search.com, which is about 5-10x normal.  

<img width="385" height="325" alt="load" src="https://github.com/user-attachments/assets/0127e9e6-e8ca-4c3b-8fa6-7d139db8d012" />

<img width="385" height="335" alt="load2" src="https://github.com/user-attachments/assets/495d6740-99d6-4b9b-9216-5dc8f74b9cac" />

As an emergency countermeasure, the search engine will automatically enter a mode during sustained high query rates (>5 QPS), where it link to a redirect page instead of the search result itself, thus rendering the search results unpaleatable for scrapers.

The redirect link has the format

`/r/{node}/{docid}/{ts}?hash=urlencoded-sha256`

Where `node` and `docid` are needed by the search engine to retrieve the URL, and and `ts` is a nanosecond timestamp unique to the search request.   This is hashed using SHA-256, along with the remote IP and a random salt.

This lets us validate how rapidly result links are being "clicked", and whether there is a discrepancy between the IP responsible for the search query and the IP that "clicks" the link, without relating the click back to the query.  

At this point validation failures will just redirect to an interstitial wait page. 

This emergency measure is designed to be as unobtrusive and respectful of privacy as possible, and the mode toggles off automatically as soon as the average query rate drops below 5 QPS.